### PR TITLE
fix: Set target framework to netstandard2.1 #151894

### DIFF
--- a/src/Audacia.Core/Audacia.Core.csproj
+++ b/src/Audacia.Core/Audacia.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
         <Version>1.1.0.0</Version>
         <AssemblyVersion>1.0.0.0</AssemblyVersion>
         <Authors>Audacia</Authors>
@@ -22,6 +22,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     </ItemGroup>
     <ItemGroup>
         <EditorConfigFiles Remove="C:\Repos\Audacia.Core\src\Audacia.Core\.editorconfig" />

--- a/src/Audacia.Core/DateTimeOffsetProvider.cs
+++ b/src/Audacia.Core/DateTimeOffsetProvider.cs
@@ -1,27 +1,28 @@
 ﻿using System;
 
-namespace Audacia.Core;
-
-/// <summary>
-/// A default instance of DateTime provider to provide the standard Now, UtcNow and Today functionality.
-/// </summary>
-public static class DateTimeOffsetProvider
+namespace Audacia.Core
 {
-    private static readonly IDateTimeOffsetProvider DefaultProviderInstance = new DefaultDateTimeProvider();
-
     /// <summary>
-    /// Gets default Instance as a singleton.
+    /// A default instance of DateTime provider to provide the standard Now, UtcNow and Today functionality.
     /// </summary>
-    public static IDateTimeOffsetProvider Instance { get; } = DefaultProviderInstance;
-
-    private class DefaultDateTimeProvider : IDateTimeOffsetProvider
+    public static class DateTimeOffsetProvider
     {
-        public DateTimeOffset UtcNow => DateTimeOffset.UtcNow;
+        private static readonly IDateTimeOffsetProvider DefaultProviderInstance = new DefaultDateTimeProvider();
 
-        public DateTimeOffset Now => DateTimeOffset.Now;
+        /// <summary>
+        /// Gets default Instance as a singleton.
+        /// </summary>
+        public static IDateTimeOffsetProvider Instance { get; } = DefaultProviderInstance;
 
-        public DateTimeOffset Today => DateTime.Today;
+        private class DefaultDateTimeProvider : IDateTimeOffsetProvider
+        {
+            public DateTimeOffset UtcNow => DateTimeOffset.UtcNow;
 
-        public DateTimeOffset UtcToday => new DateTimeOffset(DateTimeOffset.UtcNow.Date, default(TimeSpan));
+            public DateTimeOffset Now => DateTimeOffset.Now;
+
+            public DateTimeOffset Today => DateTime.Today;
+
+            public DateTimeOffset UtcToday => new DateTimeOffset(DateTimeOffset.UtcNow.Date, default(TimeSpan));
+        }
     }
 }

--- a/src/Audacia.Core/DisposableSwitch.cs
+++ b/src/Audacia.Core/DisposableSwitch.cs
@@ -1,31 +1,32 @@
 ﻿using System;
 
-namespace Audacia.Core;
-
-/// <summary>
-/// A disposable class with events to handle IDisposable. 
-/// </summary>
-[System.Diagnostics.CodeAnalysis.SuppressMessage("IDisposableAnalyzers.Correctness", "IDISP025:Class with no virtual dispose method should be sealed", Justification = "Class needs to be inherited.")]
-[System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1063:Implement IDisposable Correctly", Justification = "No managed resources inherited.")]
-public class DisposableSwitch : IDisposable
+namespace Audacia.Core
 {
-    private readonly Action _onDispose;
-
     /// <summary>
-    /// Initialize a new instance of <see cref="DisposableSwitch"/>.
+    /// A disposable class with events to handle IDisposable. 
     /// </summary>
-    /// <param name="onInit">Action to invoke when class is initialized.</param>
-    /// <param name="onDispose">Action to invoke when class is disposed.</param>
-    public DisposableSwitch(Action onInit, Action onDispose)
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("IDisposableAnalyzers.Correctness", "IDISP025:Class with no virtual dispose method should be sealed", Justification = "Class needs to be inherited.")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1063:Implement IDisposable Correctly", Justification = "No managed resources inherited.")]
+    public class DisposableSwitch : IDisposable
     {
-        _onDispose = onDispose;
-        onInit?.Invoke();
-    }
+        private readonly Action _onDispose;
 
-    /// <inheritdoc/>
-    public void Dispose()
-    {
-        _onDispose();
-        GC.SuppressFinalize(this);
+        /// <summary>
+        /// Initialize a new instance of <see cref="DisposableSwitch"/>.
+        /// </summary>
+        /// <param name="onInit">Action to invoke when class is initialized.</param>
+        /// <param name="onDispose">Action to invoke when class is disposed.</param>
+        public DisposableSwitch(Action onInit, Action onDispose)
+        {
+            _onDispose = onDispose;
+            onInit?.Invoke();
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            _onDispose();
+            GC.SuppressFinalize(this);
+        }
     }
 }

--- a/src/Audacia.Core/EnumMember.cs
+++ b/src/Audacia.Core/EnumMember.cs
@@ -8,439 +8,462 @@ using System.Reflection;
 using System.Runtime.Serialization;
 using Audacia.Core.Extensions;
 
-namespace Audacia.Core;
-
-/// <summary>
-/// Provides a set of functions for converting enums to display name strings and back again.
-/// Supported attributes are;
-/// <see cref="DisplayNameAttribute"/>,
-/// <see cref="DisplayAttribute"/>,
-/// <see cref="DescriptionAttribute"/>,
-/// <see cref="EnumMemberAttribute"/>.
-/// </summary>
-[System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "AV1710:Member name includes the name of its containing type", 
-    Justification = "This helper class includes its own name in a number of it's members, this is reference to the 'EnumMemberAttribute' as is chose to clearly indicate the source of the value.")]
-public static class EnumMember
+namespace Audacia.Core
 {
     /// <summary>
-    /// Retrieves the description for all fields on the provided enum type.
-    /// For fields without a <see cref="DescriptionAttribute"/>, <see langword="null"/> will be returned.
+    /// Provides a set of functions for converting enums to display name strings and back again.
+    /// Supported attributes are;
+    /// <see cref="DisplayNameAttribute"/>,
+    /// <see cref="DisplayAttribute"/>,
+    /// <see cref="DescriptionAttribute"/>,
+    /// <see cref="EnumMemberAttribute"/>.
     /// </summary>
-    /// <param name="enumType">Enum type.</param>
-    /// <returns>A list of descriptions from the provided enum type.</returns>
-    public static IEnumerable<string?> Descriptions(Type enumType)
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "AV1710:Member name includes the name of its containing type",
+        Justification = "This helper class includes its own name in a number of it's members, this is reference to the 'EnumMemberAttribute' as is chose to clearly indicate the source of the value.")]
+    public static class EnumMember
     {
-        enumType = ValidateEnumType(enumType);
-
-        foreach (var value in Enum.GetValues(enumType))
+        /// <summary>
+        /// Retrieves the description for all fields on the provided enum type.
+        /// For fields without a <see cref="DescriptionAttribute"/>, <see langword="null"/> will be returned.
+        /// </summary>
+        /// <param name="enumType">Enum type.</param>
+        /// <returns>A list of descriptions from the provided enum type.</returns>
+        public static IEnumerable<string?> Descriptions(Type enumType)
         {
-            yield return GetDescription(value);
-        }
-    }
+            enumType = ValidateEnumType(enumType);
 
-    /// <summary>
-    /// Retrieves the description for all fields on the provided enum type.
-    /// For fields without a <see cref="DescriptionAttribute"/>, <see langword="null"/> will be returned.
-    /// </summary>
-    /// <typeparam name="TEnum">Enum type.</typeparam>
-    /// <returns>A list of descriptions from the provided enum type.</returns>
-    public static IEnumerable<string?> Descriptions<TEnum>() where TEnum : struct
-    {
-        return Descriptions(typeof(TEnum));
-    }
-
-    /// <summary>
-    /// Retrieves the enum member value for all fields on the provided enum type.
-    /// For fields without a <see cref="EnumMemberAttribute"/>, <see langword="null"/> will be returned.
-    /// </summary>
-    /// <param name="enumType">Enum type.</param>
-    /// <returns>A list of values from the provided enum type.</returns>
-    public static IEnumerable<string?> EnumMemberValues(Type enumType)
-    {
-        enumType = ValidateEnumType(enumType);
-
-        foreach (var value in Enum.GetValues(enumType))
-        {
-            yield return GetEnumMemberValue(value);
-        }
-    }
-
-    /// <summary>
-    /// Retrieves the enum member value for all fields on the provided enum type.
-    /// For fields without a <see cref="EnumMemberAttribute"/>, <see langword="null"/> will be returned.
-    /// </summary>
-    /// <typeparam name="TEnum">Enum type.</typeparam>
-    /// <returns>A list of values from the provided enum type.</returns>
-    public static IEnumerable<string?> EnumMemberValues<TEnum>() where TEnum : struct
-    {
-        return EnumMemberValues(typeof(TEnum));
-    }
-
-    /// <summary>
-    /// Retrieves the field name for all fields on the provided enum type.
-    /// </summary>
-    /// <param name="enumType">Enum type.</param>
-    /// <returns>A list of names from the provided enum type.</returns>
-    public static IEnumerable<string?> Names(Type enumType)
-    {
-        enumType = ValidateEnumType(enumType);
-
-        foreach (var value in Enum.GetValues(enumType))
-        {
-            yield return GetName(value);
-        }
-    }
-
-    /// <summary>
-    /// Retrieves the field name for all fields on the provided enum type.
-    /// </summary>
-    /// <typeparam name="TEnum">Enum type.</typeparam>
-    /// <returns>A list of names from the provided enum type.</returns>
-    public static IEnumerable<string?> Names<TEnum>() where TEnum : struct
-    {
-        return Names(typeof(TEnum));
-    }
-
-    /// <summary>
-    /// Retrieves the first available human readable name for all fields in the provided enum type.
-    /// </summary>
-    /// <param name="enumType">Enum type.</param>
-    /// <returns>A list of human readble names from the provided enum type.</returns>
-    public static IEnumerable<string?> Options(Type enumType)
-    {
-        enumType = ValidateEnumType(enumType);
-
-        foreach (var value in Enum.GetValues(enumType))
-        {
-            yield return GetOption(value);
-        }
-    }
-
-    /// <summary>
-    /// Retrieves the first available human readable name for all fields in the provided enum type.
-    /// </summary>
-    /// <typeparam name="TEnum">Enum type.</typeparam>
-    /// <returns>A list of human readble names from the provided enum type.</returns>
-    public static IEnumerable<string?> Options<TEnum>() where TEnum : struct
-    {
-        return Options(typeof(TEnum));
-    }
-
-    /// <summary>
-    /// Returns the value set on the <see cref="DescriptionAttribute"/>.
-    /// For fields without a <see cref="DescriptionAttribute"/>, <see langword="null"/> will be returned.
-    /// </summary>
-    /// <param name="enumValue">Enum value.</param>
-    /// <returns>The description string.</returns>
-    /// <returns>The value of <see cref="DescriptionAttribute"/> from the provided <paramref name="enumValue"/>.</returns>
-    public static string? GetDescription(object enumValue)
-    {
-        ArgumentNullException.ThrowIfNull(enumValue);
-
-        var enumType = enumValue.GetType().GetUnderlyingTypeIfNullable();
-
-        enumType = ValidateEnumType(enumType);
-
-        return GetFieldInfo(enumValue)
-            ?.GetCustomAttribute<DescriptionAttribute>(false)
-            ?.Description;
-    }
-
-    /// <summary>
-    /// Returns the value set on the <see cref="EnumMemberAttribute"/>.
-    /// For fields without a <see cref="EnumMemberAttribute"/>, <see langword="null"/> will be returned.
-    /// </summary>
-    /// <param name="enumValue">Enum value.</param>
-    /// <returns>The enummember value string.</returns>
-    public static string? GetEnumMemberValue(object enumValue)
-    {
-        ArgumentNullException.ThrowIfNull(enumValue);
-
-        var enumType = enumValue.GetType().GetUnderlyingTypeIfNullable();
-
-        enumType = ValidateEnumType(enumType);
-
-        return GetFieldInfo(enumValue)
-            ?.GetCustomAttribute<EnumMemberAttribute>(false)
-            ?.Value;
-    }
-
-    /// <summary>
-    /// Returns the field name for the enum value.
-    /// </summary>
-    /// <param name="enumValue">Enum value.</param>
-    /// <returns>The field name.</returns>
-    public static string? GetName(object enumValue)
-    {
-        ArgumentNullException.ThrowIfNull(enumValue);
-
-        var enumType = enumValue.GetType().GetUnderlyingTypeIfNullable();
-
-        enumType = ValidateEnumType(enumType);
-
-        return GetFieldInfo(enumValue)?.Name;
-    }
-
-    /// <summary>
-    /// Returns the first available human readable name for the enum value.
-    /// </summary>
-    /// <param name="enumValue">Enum value.</param>
-    /// <returns>A human readable name for the enum value.</returns>
-    public static string? GetOption(object enumValue)
-    {
-        return GetDescription(enumValue) ??
-               GetEnumMemberValue(enumValue) ??
-               GetName(enumValue) ??
-               enumValue?.ToString();
-    }
-
-    /// <summary>
-    /// Returns the enum value as a text integer.
-    /// </summary>
-    /// <param name="enumValue">Enum value.</param>
-    /// <returns>The field name.</returns>
-    public static string? GetValue(object enumValue)
-    {
-        ArgumentNullException.ThrowIfNull(enumValue);
-
-        var enumType = enumValue.GetType().GetUnderlyingTypeIfNullable();
-
-        ValidateEnumType(enumType);
-
-        return Convert.ToInt32(enumValue, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture);
-    }
-
-    /// <summary>
-    /// Gets the value of an enum which corresponds to the specified enum member, display name, or description.
-    /// </summary>
-    /// <typeparam name="TEnum">Enum type.</typeparam>
-    /// <param name="value">Input value.</param>
-    /// <exception cref="ArgumentNullException">enumType or value is null.</exception>
-    /// <exception cref="ArgumentException">
-    ///     enumType is not an System.Enum.
-    ///     Or value is either an empty string, or only contains whitespace.
-    ///     Or value is a name, but not one of the named constants defined for the enumeration.
-    /// </exception>
-    /// <exception cref="OverflowException">value is outside the range of the underlying type of enumType.</exception>
-    /// <returns>The enum value as an object.</returns>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1551:Method overload should call another overload", Justification = "Method calls Parse(Type enumType, string value)")]
-    public static TEnum? Parse<TEnum>(string value) where TEnum : struct
-    {
-        return (TEnum?)Parse(typeof(TEnum?), value ?? string.Empty);
-    }
-
-    /// <summary>
-    /// Gets the value of an enum which corresponds to the specified enum member, display name, or description.
-    /// </summary>
-    /// <param name="enumType">Enum type.</param>
-    /// <param name="value">Input value.</param>
-    /// <exception cref="ArgumentNullException">enumType or value is null.</exception>
-    /// <exception cref="ArgumentException">
-    ///     enumType is not an System.Enum.
-    ///     Or value is either an empty string, or only contains whitespace.
-    ///     Or value is a name, but not one of the named constants defined for the enumeration.
-    /// </exception>
-    /// <exception cref="OverflowException">value is outside the range of the underlying type of enumType.</exception>
-    /// <returns>The enum value as an object.</returns>
-    public static object? Parse(Type enumType, string value)
-    {
-        enumType = ValidateEnumType(enumType);
-
-        value = SanitizeDisplayNameString(value) ?? string.Empty;
-        ValidateValueString(value);
-
-        object? enumValue = GetEnumValue(enumType, value);
-
-        // Get an enumerable of enum options
-        var fields = enumType.GetFields().Where(f => f.IsStatic);
-
-        // Attempt to match to each possible display value
-        foreach (var field in fields)
-        {
-            if (MatchesEnumMember(field, value) ||
-                MatchesDescription(field, value) ||
-                MatchesName(field, value) ||
-                MatchesDisplay(field, value))
+            foreach (var value in Enum.GetValues(enumType))
             {
-                return field.GetValue(null) ?? default!;
+                yield return GetDescription(value);
             }
         }
 
-        throw new ArgumentException($"Requested value '{value}' was not found.");
-    }
-
-    /// <summary>
-    /// Gets the value of an enum which corresponds to the specified enum member, display name, or description.
-    /// </summary>
-    /// <param name="enumType">Enum type.</param>
-    /// <param name="value">Input value.</param>
-    /// <param name="enumValue">The enum value as an object.</param>
-    /// <returns><see langword="true" /> if parsed successfully.</returns>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Matters more if there *is* an error more than *what* error.")]
-    public static bool TryParse(Type enumType, string value, out object? enumValue)
-    {
-        try
+        /// <summary>
+        /// Retrieves the description for all fields on the provided enum type.
+        /// For fields without a <see cref="DescriptionAttribute"/>, <see langword="null"/> will be returned.
+        /// </summary>
+        /// <typeparam name="TEnum">Enum type.</typeparam>
+        /// <returns>A list of descriptions from the provided enum type.</returns>
+        public static IEnumerable<string?> Descriptions<TEnum>() where TEnum : struct
         {
-            enumValue = Parse(enumType, value);
-            return true;
-        }
-        catch
-        {
-            enumValue = null;
+            return Descriptions(typeof(TEnum));
         }
 
-        return false;
-    }
-
-    /// <summary>
-    /// Gets the value of an enum which corresponds to the specified enum member, display name, or description.
-    /// </summary>
-    /// <typeparam name="TEnum">Enum type.</typeparam>
-    /// <param name="value">Input value.</param>
-    /// <param name="enumValue">The enum value as an object.</param>
-    /// <returns><see langword="true" /> if parsed successfully.</returns>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1551:Method overload should call another overload", Justification = "Method calls TryParse(Type enumType, string value, out object? enumValue)")]
-    public static bool TryParse<TEnum>(string value, out TEnum? enumValue) where TEnum : struct
-    {
-        if (TryParse(typeof(TEnum), value, out var enumObj))
+        /// <summary>
+        /// Retrieves the enum member value for all fields on the provided enum type.
+        /// For fields without a <see cref="EnumMemberAttribute"/>, <see langword="null"/> will be returned.
+        /// </summary>
+        /// <param name="enumType">Enum type.</param>
+        /// <returns>A list of values from the provided enum type.</returns>
+        public static IEnumerable<string?> EnumMemberValues(Type enumType)
         {
-            enumValue = (TEnum?)enumObj;
-            return true;
+            enumType = ValidateEnumType(enumType);
+
+            foreach (var value in Enum.GetValues(enumType))
+            {
+                yield return GetEnumMemberValue(value);
+            }
         }
 
-        enumValue = default(TEnum);
-        return false;
-    }
-
-    /// <summary>
-    /// Retrieves the value for all fields on the provided enum type.
-    /// </summary>
-    /// <param name="enumType">Enum type.</param>
-    /// <returns>An integer array of enum values.</returns>
-    public static IEnumerable<int> Values(Type enumType)
-    {
-        enumType = ValidateEnumType(enumType);
-
-        return (int[])Enum.GetValues(enumType);
-    }
-
-    /// <summary>
-    /// Retrieves the value for all fields on the provided enum type.
-    /// </summary>
-    /// <typeparam name="TEnum">Enum type.</typeparam>
-    /// <returns>An array of enum values.</returns>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1551:Method overload should call another overload", Justification = "Other 'overload' method has different return type.")]
-    public static IEnumerable<TEnum> Values<TEnum>() where TEnum : struct
-    {
-        var enumType = typeof(TEnum);
-        enumType = ValidateEnumType(enumType);
-
-        return (TEnum[])Enum.GetValues(typeof(TEnum));
-    }
-
-    private static FieldInfo? GetFieldInfo(object enumValue)
-    {
-        return enumValue.GetType().GetField(enumValue.ToString() ?? string.Empty);
-    }
-
-    private static bool MatchesDescription(MemberInfo member, string? value)
-    {
-        var attribute = member.GetCustomAttribute<DescriptionAttribute>(false);
-
-        if (attribute != null)
+        /// <summary>
+        /// Retrieves the enum member value for all fields on the provided enum type.
+        /// For fields without a <see cref="EnumMemberAttribute"/>, <see langword="null"/> will be returned.
+        /// </summary>
+        /// <typeparam name="TEnum">Enum type.</typeparam>
+        /// <returns>A list of values from the provided enum type.</returns>
+        public static IEnumerable<string?> EnumMemberValues<TEnum>() where TEnum : struct
         {
-            return string.Equals(attribute.Description, value, StringComparison.OrdinalIgnoreCase);
+            return EnumMemberValues(typeof(TEnum));
         }
 
-        return false;
-    }
-
-    private static bool MatchesEnumMember(MemberInfo member, string? value)
-    {
-        var attribute = member.GetCustomAttribute<EnumMemberAttribute>(false);
-
-        if (attribute != null)
+        /// <summary>
+        /// Retrieves the field name for all fields on the provided enum type.
+        /// </summary>
+        /// <param name="enumType">Enum type.</param>
+        /// <returns>A list of names from the provided enum type.</returns>
+        public static IEnumerable<string?> Names(Type enumType)
         {
-            return string.Equals(attribute.Value, value, StringComparison.OrdinalIgnoreCase);
+            enumType = ValidateEnumType(enumType);
+
+            foreach (var value in Enum.GetValues(enumType))
+            {
+                yield return GetName(value);
+            }
         }
 
-        return false;
-    }
-
-    private static bool MatchesDisplay(MemberInfo member, string? value)
-    {
-        var attribute = member.GetCustomAttribute<DisplayAttribute>(false);
-
-        if (attribute != null)
+        /// <summary>
+        /// Retrieves the field name for all fields on the provided enum type.
+        /// </summary>
+        /// <typeparam name="TEnum">Enum type.</typeparam>
+        /// <returns>A list of names from the provided enum type.</returns>
+        public static IEnumerable<string?> Names<TEnum>() where TEnum : struct
         {
-            return string.Equals(attribute.Name, value, StringComparison.OrdinalIgnoreCase);
+            return Names(typeof(TEnum));
         }
 
-        return false;
-    }
-
-    private static bool MatchesName(MemberInfo member, string? value)
-    {
-        return string.Equals(member.Name, value, StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static string? SanitizeDisplayNameString(string? value)
-    {
-        // Ignore long dashes from user input
-        return value?.Replace("–", "-", StringComparison.InvariantCulture).Trim();
-    }
-
-    private static Type ValidateEnumType(Type enumType)
-    {
-        ArgumentNullException.ThrowIfNull(enumType);
-
-        if (enumType.IsNullable())
+        /// <summary>
+        /// Retrieves the first available human readable name for all fields in the provided enum type.
+        /// </summary>
+        /// <param name="enumType">Enum type.</param>
+        /// <returns>A list of human readble names from the provided enum type.</returns>
+        public static IEnumerable<string?> Options(Type enumType)
         {
-            enumType = enumType.GetUnderlyingTypeIfNullable();
+            enumType = ValidateEnumType(enumType);
+
+            foreach (var value in Enum.GetValues(enumType))
+            {
+                yield return GetOption(value);
+            }
         }
 
-        if (!enumType.IsEnum)
+        /// <summary>
+        /// Retrieves the first available human readable name for all fields in the provided enum type.
+        /// </summary>
+        /// <typeparam name="TEnum">Enum type.</typeparam>
+        /// <returns>A list of human readble names from the provided enum type.</returns>
+        public static IEnumerable<string?> Options<TEnum>() where TEnum : struct
         {
-            throw new ArgumentException("Type must be an enum type.", nameof(enumType));
+            return Options(typeof(TEnum));
         }
 
-        return enumType;
-    }
-
-    private static void ValidateValueString(string? value)
-    {
-        ArgumentNullException.ThrowIfNull(value);
-
-        if (string.IsNullOrWhiteSpace(value))
+        /// <summary>
+        /// Returns the value set on the <see cref="DescriptionAttribute"/>.
+        /// For fields without a <see cref="DescriptionAttribute"/>, <see langword="null"/> will be returned.
+        /// </summary>
+        /// <param name="enumValue">Enum value.</param>
+        /// <returns>The description string.</returns>
+        /// <returns>The value of <see cref="DescriptionAttribute"/> from the provided <paramref name="enumValue"/>.</returns>
+        /// <exception cref="ArgumentNullException">enumType or value is null.</exception>
+        public static string? GetDescription(object enumValue)
         {
-            throw new ArgumentException("Value cannot be empty or whitespace.", nameof(value));
-        }
-    }
+            if (enumValue == null)
+            {
+                throw new ArgumentNullException(nameof(enumValue));
+            }
 
-    private static object? GetEnumValue(Type enumType, string? value)
-    {
-        bool enumDefined;
-        object? enumValue;
+            var enumType = enumValue.GetType().GetUnderlyingTypeIfNullable();
 
-        try
-        {
-            // Match by number value or field name
-            enumValue = Enum.Parse(enumType, value ?? string.Empty, ignoreCase: true);
-            enumDefined = Enum.IsDefined(enumType, enumValue);
-        }
-        catch (ArgumentException)
-        {
-            // Ignore enum value not found error
-            enumValue = null;
-            enumDefined = false;
+            enumType = ValidateEnumType(enumType);
+
+            return GetFieldInfo(enumValue)
+                ?.GetCustomAttribute<DescriptionAttribute>(false)
+                ?.Description;
         }
 
-        if (!enumDefined && enumValue != null)
+        /// <summary>
+        /// Returns the value set on the <see cref="EnumMemberAttribute"/>.
+        /// For fields without a <see cref="EnumMemberAttribute"/>, <see langword="null"/> will be returned.
+        /// </summary>
+        /// <param name="enumValue">Enum value.</param>
+        /// <returns>The enummember value string.</returns>
+        /// <exception cref="ArgumentNullException">enumType or value is null.</exception>
+        public static string? GetEnumMemberValue(object enumValue)
         {
-            throw new OverflowException($"Value '{value}' is outside the range of '{enumType.Name}'.");
+            if (enumValue == null)
+            {
+                throw new ArgumentNullException(nameof(enumValue));
+            }
+
+            var enumType = enumValue.GetType().GetUnderlyingTypeIfNullable();
+
+            enumType = ValidateEnumType(enumType);
+
+            return GetFieldInfo(enumValue)
+                ?.GetCustomAttribute<EnumMemberAttribute>(false)
+                ?.Value;
         }
 
-        // Enum was parsed successfully, and is in defined on the enum type
-        return enumValue;
+        /// <summary>
+        /// Returns the field name for the enum value.
+        /// </summary>
+        /// <param name="enumValue">Enum value.</param>
+        /// <returns>The field name.</returns>
+        /// <exception cref="ArgumentNullException">enumType or value is null.</exception>
+        public static string? GetName(object enumValue)
+        {
+            if (enumValue == null)
+            {
+                throw new ArgumentNullException(nameof(enumValue));
+            }
+
+            var enumType = enumValue.GetType().GetUnderlyingTypeIfNullable();
+
+            enumType = ValidateEnumType(enumType);
+
+            return GetFieldInfo(enumValue)?.Name;
+        }
+
+        /// <summary>
+        /// Returns the first available human readable name for the enum value.
+        /// </summary>
+        /// <param name="enumValue">Enum value.</param>
+        /// <returns>A human readable name for the enum value.</returns>
+        public static string? GetOption(object enumValue)
+        {
+            return GetDescription(enumValue) ??
+                   GetEnumMemberValue(enumValue) ??
+                   GetName(enumValue) ??
+                   enumValue?.ToString();
+        }
+
+        /// <summary>
+        /// Returns the enum value as a text integer.
+        /// </summary>
+        /// <param name="enumValue">Enum value.</param>
+        /// <returns>The field name.</returns>
+        /// <exception cref="ArgumentNullException">enumType or value is null.</exception>
+        public static string? GetValue(object enumValue)
+        {
+            if (enumValue == null)
+            {
+                throw new ArgumentNullException(nameof(enumValue));
+            }
+
+            var enumType = enumValue.GetType().GetUnderlyingTypeIfNullable();
+
+            ValidateEnumType(enumType);
+
+            return Convert.ToInt32(enumValue, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Gets the value of an enum which corresponds to the specified enum member, display name, or description.
+        /// </summary>
+        /// <typeparam name="TEnum">Enum type.</typeparam>
+        /// <param name="value">Input value.</param>
+        /// <exception cref="ArgumentNullException">enumType or value is null.</exception>
+        /// <exception cref="ArgumentException">
+        ///     enumType is not an System.Enum.
+        ///     Or value is either an empty string, or only contains whitespace.
+        ///     Or value is a name, but not one of the named constants defined for the enumeration.
+        /// </exception>
+        /// <exception cref="OverflowException">value is outside the range of the underlying type of enumType.</exception>
+        /// <returns>The enum value as an object.</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1551:Method overload should call another overload", Justification = "Method calls Parse(Type enumType, string value)")]
+        public static TEnum? Parse<TEnum>(string value) where TEnum : struct
+        {
+            return (TEnum?)Parse(typeof(TEnum?), value ?? string.Empty);
+        }
+
+        /// <summary>
+        /// Gets the value of an enum which corresponds to the specified enum member, display name, or description.
+        /// </summary>
+        /// <param name="enumType">Enum type.</param>
+        /// <param name="value">Input value.</param>
+        /// <exception cref="ArgumentNullException">enumType or value is null.</exception>
+        /// <exception cref="ArgumentException">
+        ///     enumType is not an System.Enum.
+        ///     Or value is either an empty string, or only contains whitespace.
+        ///     Or value is a name, but not one of the named constants defined for the enumeration.
+        /// </exception>
+        /// <exception cref="OverflowException">value is outside the range of the underlying type of enumType.</exception>
+        /// <returns>The enum value as an object.</returns>
+        public static object? Parse(Type enumType, string value)
+        {
+            enumType = ValidateEnumType(enumType);
+
+            value = SanitizeDisplayNameString(value) ?? string.Empty;
+            ValidateValueString(value);
+
+            object? enumValue = GetEnumValue(enumType, value);
+
+            // Get an enumerable of enum options
+            var fields = enumType.GetFields().Where(f => f.IsStatic);
+
+            // Attempt to match to each possible display value
+            foreach (var field in fields)
+            {
+                if (MatchesEnumMember(field, value) ||
+                    MatchesDescription(field, value) ||
+                    MatchesName(field, value) ||
+                    MatchesDisplay(field, value))
+                {
+                    return field.GetValue(null) ?? default!;
+                }
+            }
+
+            throw new ArgumentException($"Requested value '{value}' was not found.");
+        }
+
+        /// <summary>
+        /// Gets the value of an enum which corresponds to the specified enum member, display name, or description.
+        /// </summary>
+        /// <param name="enumType">Enum type.</param>
+        /// <param name="value">Input value.</param>
+        /// <param name="enumValue">The enum value as an object.</param>
+        /// <returns><see langword="true" /> if parsed successfully.</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Matters more if there *is* an error more than *what* error.")]
+        public static bool TryParse(Type enumType, string value, out object? enumValue)
+        {
+            try
+            {
+                enumValue = Parse(enumType, value);
+                return true;
+            }
+            catch
+            {
+                enumValue = null;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Gets the value of an enum which corresponds to the specified enum member, display name, or description.
+        /// </summary>
+        /// <typeparam name="TEnum">Enum type.</typeparam>
+        /// <param name="value">Input value.</param>
+        /// <param name="enumValue">The enum value as an object.</param>
+        /// <returns><see langword="true" /> if parsed successfully.</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1551:Method overload should call another overload", Justification = "Method calls TryParse(Type enumType, string value, out object? enumValue)")]
+        public static bool TryParse<TEnum>(string value, out TEnum? enumValue) where TEnum : struct
+        {
+            if (TryParse(typeof(TEnum), value, out var enumObj))
+            {
+                enumValue = (TEnum?)enumObj;
+                return true;
+            }
+
+            enumValue = default(TEnum);
+            return false;
+        }
+
+        /// <summary>
+        /// Retrieves the value for all fields on the provided enum type.
+        /// </summary>
+        /// <param name="enumType">Enum type.</param>
+        /// <returns>An integer array of enum values.</returns>
+        public static IEnumerable<int> Values(Type enumType)
+        {
+            enumType = ValidateEnumType(enumType);
+
+            return (int[])Enum.GetValues(enumType);
+        }
+
+        /// <summary>
+        /// Retrieves the value for all fields on the provided enum type.
+        /// </summary>
+        /// <typeparam name="TEnum">Enum type.</typeparam>
+        /// <returns>An array of enum values.</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1551:Method overload should call another overload", Justification = "Other 'overload' method has different return type.")]
+        public static IEnumerable<TEnum> Values<TEnum>() where TEnum : struct
+        {
+            var enumType = typeof(TEnum);
+            enumType = ValidateEnumType(enumType);
+
+            return (TEnum[])Enum.GetValues(typeof(TEnum));
+        }
+
+        private static FieldInfo? GetFieldInfo(object enumValue)
+        {
+            return enumValue.GetType().GetField(enumValue.ToString() ?? string.Empty);
+        }
+
+        private static bool MatchesDescription(MemberInfo member, string? value)
+        {
+            var attribute = member.GetCustomAttribute<DescriptionAttribute>(false);
+
+            if (attribute != null)
+            {
+                return string.Equals(attribute.Description, value, StringComparison.OrdinalIgnoreCase);
+            }
+
+            return false;
+        }
+
+        private static bool MatchesEnumMember(MemberInfo member, string? value)
+        {
+            var attribute = member.GetCustomAttribute<EnumMemberAttribute>(false);
+
+            if (attribute != null)
+            {
+                return string.Equals(attribute.Value, value, StringComparison.OrdinalIgnoreCase);
+            }
+
+            return false;
+        }
+
+        private static bool MatchesDisplay(MemberInfo member, string? value)
+        {
+            var attribute = member.GetCustomAttribute<DisplayAttribute>(false);
+
+            if (attribute != null)
+            {
+                return string.Equals(attribute.Name, value, StringComparison.OrdinalIgnoreCase);
+            }
+
+            return false;
+        }
+
+        private static bool MatchesName(MemberInfo member, string? value)
+        {
+            return string.Equals(member.Name, value, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string? SanitizeDisplayNameString(string? value)
+        {
+            // Ignore long dashes from user input
+            return value?.Replace("–", "-", StringComparison.InvariantCulture).Trim();
+        }
+
+        private static Type ValidateEnumType(Type enumType)
+        {
+            if (enumType == null)
+            {
+                throw new ArgumentNullException(nameof(enumType));
+            }
+
+            if (enumType.IsNullable())
+            {
+                enumType = enumType.GetUnderlyingTypeIfNullable();
+            }
+
+            if (!enumType.IsEnum)
+            {
+                throw new ArgumentException("Type must be an enum type.", nameof(enumType));
+            }
+
+            return enumType;
+        }
+
+        private static void ValidateValueString(string? value)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new ArgumentException("Value cannot be empty or whitespace.", nameof(value));
+            }
+        }
+
+        private static object? GetEnumValue(Type enumType, string? value)
+        {
+            bool enumDefined;
+            object? enumValue;
+
+            try
+            {
+                // Match by number value or field name
+                enumValue = Enum.Parse(enumType, value ?? string.Empty, ignoreCase: true);
+                enumDefined = Enum.IsDefined(enumType, enumValue);
+            }
+            catch (ArgumentException)
+            {
+                // Ignore enum value not found error
+                enumValue = null;
+                enumDefined = false;
+            }
+
+            if (!enumDefined && enumValue != null)
+            {
+                throw new OverflowException($"Value '{value}' is outside the range of '{enumType.Name}'.");
+            }
+
+            // Enum was parsed successfully, and is in defined on the enum type
+            return enumValue;
+        }
     }
 }

--- a/src/Audacia.Core/Extensions/AssemblyExtensions.cs
+++ b/src/Audacia.Core/Extensions/AssemblyExtensions.cs
@@ -3,33 +3,37 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
-namespace Audacia.Core.Extensions;
-
-/// <summary>
-/// Extension methods for the type <see cref="Assembly"/>.
-/// </summary>
-public static class AssemblyExtensions
+namespace Audacia.Core.Extensions
 {
     /// <summary>
-    /// Get a collection of types from an assembly that match the type <typeparamref name="TFilterType"/>.
+    /// Extension methods for the type <see cref="Assembly"/>.
     /// </summary>
-    /// <typeparam name="TFilterType">A type to filter the assembly parameters.</typeparam>
-    /// <param name="assembly">The source assembly.</param>
-    /// <returns>A collection of <typeparamref name="TFilterType"/>.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="assembly"/> is null.</exception>
-    public static IEnumerable<TFilterType> GetNewInstancesOfInheritingTypesWithParameterlessConstructors<TFilterType>(this Assembly assembly) where TFilterType : class
+    public static class AssemblyExtensions
     {
-        ArgumentNullException.ThrowIfNull(assembly);
+        /// <summary>
+        /// Get a collection of types from an assembly that match the type <typeparamref name="TFilterType"/>.
+        /// </summary>
+        /// <typeparam name="TFilterType">A type to filter the assembly parameters.</typeparam>
+        /// <param name="assembly">The source assembly.</param>
+        /// <returns>A collection of <typeparamref name="TFilterType"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="assembly"/> is null.</exception>
+        public static IEnumerable<TFilterType> GetNewInstancesOfInheritingTypesWithParameterlessConstructors<TFilterType>(this Assembly assembly) where TFilterType : class
+        {
+            if (assembly == null)
+            {
+                throw new ArgumentNullException(nameof(assembly));
+            }
 
-        var filterType = typeof(TFilterType);
+            var filterType = typeof(TFilterType);
 
-        var result = from type in assembly.GetTypes()
-                     where filterType.IsAssignableFrom(type) //Check if it is a FilterType
-                     where type != filterType //Check that it is not FilterType itself                       
-                     where type.GetConstructor(Type.EmptyTypes) != null //Check that is has a parameterless constructor
-                     let instance = Activator.CreateInstance(type)
-                     select instance as TFilterType;
+            var result = from type in assembly.GetTypes()
+                         where filterType.IsAssignableFrom(type) //Check if it is a FilterType
+                         where type != filterType //Check that it is not FilterType itself                       
+                         where type.GetConstructor(Type.EmptyTypes) != null //Check that is has a parameterless constructor
+                         let instance = Activator.CreateInstance(type)
+                         select instance as TFilterType;
 
-        return result.ToList() ?? default!;
+            return result.ToList() ?? default!;
+        }
     }
 }

--- a/src/Audacia.Core/Extensions/CollectionExtensions.cs
+++ b/src/Audacia.Core/Extensions/CollectionExtensions.cs
@@ -1,88 +1,89 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace Audacia.Core.Extensions;
-
-/// <summary>
-/// Extension methods for the type <see cref="ICollection{T}"/>.
-/// </summary>
-public static class CollectionExtensions
+namespace Audacia.Core.Extensions
 {
     /// <summary>
-    /// Adds <paramref name="item"/> to <paramref name="collection"/> if it doesn't already exist within it.
+    /// Extension methods for the type <see cref="ICollection{T}"/>.
     /// </summary>
-    /// <typeparam name="T">The type of the collection <paramref name="collection"/> and item <paramref name="item"/>.</typeparam>
-    /// <param name="collection">A collection of type <typeparamref name="T"/>.</param>
-    /// <param name="item">Item to add to <paramref name="collection"/>.</param>
-    public static void AddIfNotContains<T>(this ICollection<T> collection, T item)
+    public static class CollectionExtensions
     {
-        if (collection?.Contains(item) == false)
+        /// <summary>
+        /// Adds <paramref name="item"/> to <paramref name="collection"/> if it doesn't already exist within it.
+        /// </summary>
+        /// <typeparam name="T">The type of the collection <paramref name="collection"/> and item <paramref name="item"/>.</typeparam>
+        /// <param name="collection">A collection of type <typeparamref name="T"/>.</param>
+        /// <param name="item">Item to add to <paramref name="collection"/>.</param>
+        public static void AddIfNotContains<T>(this ICollection<T> collection, T item)
         {
-            collection.Add(item);
-        }
-    }
-
-    /// <summary>
-    /// Adds the elements of the specified enumerable to the end of the collection.
-    /// </summary>
-    /// <typeparam name="T">The type of the collections <paramref name="destination"/> and <paramref name="source"/>.</typeparam>
-    /// <param name="destination">A collection of type <typeparamref name="T"/>.</param>
-    /// <param name="source">A collection of type <typeparamref name="T"/> to add to <paramref name="destination"/>.</param>
-    /// <exception cref="InvalidOperationException">Throws if collection is readonly.</exception>
-    public static void AddRange<T>(this ICollection<T> destination, IEnumerable<T> source)
-    {
-        if (source == null || destination == null)
-        {
-            return;
+            if (collection?.Contains(item) == false)
+            {
+                collection.Add(item);
+            }
         }
 
-        // Prevent add range on arrays
-        if (destination.IsReadOnly)
+        /// <summary>
+        /// Adds the elements of the specified enumerable to the end of the collection.
+        /// </summary>
+        /// <typeparam name="T">The type of the collections <paramref name="destination"/> and <paramref name="source"/>.</typeparam>
+        /// <param name="destination">A collection of type <typeparamref name="T"/>.</param>
+        /// <param name="source">A collection of type <typeparamref name="T"/> to add to <paramref name="destination"/>.</param>
+        /// <exception cref="InvalidOperationException">Throws if collection is readonly.</exception>
+        public static void AddRange<T>(this ICollection<T> destination, IEnumerable<T> source)
         {
-            throw new InvalidOperationException("Collection is read-only.");
+            if (source == null || destination == null)
+            {
+                return;
+            }
+
+            // Prevent add range on arrays
+            if (destination.IsReadOnly)
+            {
+                throw new InvalidOperationException("Collection is read-only.");
+            }
+
+            if (destination is List<T> list)
+            {
+                list.AddRange(source);
+                return;
+            }
+
+            foreach (var item in source)
+            {
+                destination.Add(item);
+            }
         }
 
-        if (destination is List<T> list)
+        /// <summary>
+        /// Removes the elements of the specified enumerable from the collection.
+        /// </summary>
+        /// <typeparam name="T">The type of the collections <paramref name="destination"/> and <paramref name="source"/>.</typeparam>
+        /// <param name="destination">A collection of type <typeparamref name="T"/>.</param>
+        /// <param name="source">A collection of type <typeparamref name="T"/> to remove from <paramref name="destination"/>.</param>
+        /// <exception cref="InvalidOperationException">Throws if collection is readonly.</exception>
+        public static void RemoveARange<T>(this ICollection<T> destination, IEnumerable<T> source)
         {
-            list.AddRange(source);
-            return;
-        }
+            if (source == null || destination == null)
+            {
+                return;
+            }
 
-        foreach (var item in source)
-        {
-            destination.Add(item);
-        }
-    }
+            // Prevent remove range on arrays
+            if (destination.IsReadOnly)
+            {
+                throw new InvalidOperationException("Collection is read-only.");
+            }
 
-    /// <summary>
-    /// Removes the elements of the specified enumerable from the collection.
-    /// </summary>
-    /// <typeparam name="T">The type of the collections <paramref name="destination"/> and <paramref name="source"/>.</typeparam>
-    /// <param name="destination">A collection of type <typeparamref name="T"/>.</param>
-    /// <param name="source">A collection of type <typeparamref name="T"/> to remove from <paramref name="destination"/>.</param>
-    /// <exception cref="InvalidOperationException">Throws if collection is readonly.</exception>
-    public static void RemoveARange<T>(this ICollection<T> destination, IEnumerable<T> source)
-    {
-        if (source == null || destination == null)
-        {
-            return;
-        }
+            if (ReferenceEquals(destination, source))
+            {
+                destination.Clear();
+                return;
+            }
 
-        // Prevent remove range on arrays
-        if (destination.IsReadOnly)
-        {
-            throw new InvalidOperationException("Collection is read-only.");
-        }
-
-        if (ReferenceEquals(destination, source))
-        {
-            destination.Clear();
-            return;
-        }
-
-        foreach (var item in source)
-        {
-            destination.Remove(item);
+            foreach (var item in source)
+            {
+                destination.Remove(item);
+            }
         }
     }
 }

--- a/src/Audacia.Core/Extensions/ColorExtensions.cs
+++ b/src/Audacia.Core/Extensions/ColorExtensions.cs
@@ -1,19 +1,20 @@
 ﻿using System.Drawing;
 
-namespace Audacia.Core.Extensions;
-
-/// <summary>
-/// Extension methods for the type <see cref="Color"/>.
-/// </summary>
-public static class ColorExtensions
+namespace Audacia.Core.Extensions
 {
     /// <summary>
-    /// Returns 6 digit hex representation of a .NET colour.
+    /// Extension methods for the type <see cref="Color"/>.
     /// </summary>
-    /// <param name="color">the colour to convert.</param>
-    /// <returns>Color as a hex string.</returns>
-    public static string ToHexString(this Color color)
+    public static class ColorExtensions
     {
-        return $"{color.R:X2}{color.G:X2}{color.B:X2}";
+        /// <summary>
+        /// Returns 6 digit hex representation of a .NET colour.
+        /// </summary>
+        /// <param name="color">the colour to convert.</param>
+        /// <returns>Color as a hex string.</returns>
+        public static string ToHexString(this Color color)
+        {
+            return $"{color.R:X2}{color.G:X2}{color.B:X2}";
+        }
     }
 }

--- a/src/Audacia.Core/Extensions/DataTableExtensions.cs
+++ b/src/Audacia.Core/Extensions/DataTableExtensions.cs
@@ -4,79 +4,83 @@ using System.Data;
 using System.Linq;
 using System.Text;
 
-namespace Audacia.Core.Extensions;
-
-/// <summary>
-/// Extension methods for the type <see cref="DataTable"/>.
-/// </summary>
-public static class DataTableExtensions
+namespace Audacia.Core.Extensions
 {
     /// <summary>
-    /// Converts a DataTable to a CSV string.
+    /// Extension methods for the type <see cref="DataTable"/>.
     /// </summary>
-    /// <param name="dataTable">The DataTable to convert.</param>
-    /// <param name="delimiter">The delimiter to use in the converted string (defaults to ',').</param>
-    /// <returns>The converted string.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="dataTable"/> is null.</exception>
-    /// <exception cref="NotSupportedException">Delimiter is invalid.</exception>
-    public static string ToCsv(this DataTable dataTable, string delimiter = ",")
+    public static class DataTableExtensions
     {
-        ValidateArguments(dataTable, delimiter);
-
-        var outputBuilder = new StringBuilder();
-
-        var headers = GetHeaders(dataTable);
-
-        outputBuilder.AppendJoin(delimiter, headers).AppendLine();
-
-        return GetRows(dataTable, delimiter, outputBuilder);
-    }
-
-    private static void ValidateArguments(DataTable dataTable, string delimiter)
-    {
-        ArgumentNullException.ThrowIfNull(dataTable);
-
-        if (delimiter == "\"")
+        /// <summary>
+        /// Converts a DataTable to a CSV string.
+        /// </summary>
+        /// <param name="dataTable">The DataTable to convert.</param>
+        /// <param name="delimiter">The delimiter to use in the converted string (defaults to ',').</param>
+        /// <returns>The converted string.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="dataTable"/> is null.</exception>
+        /// <exception cref="NotSupportedException">Delimiter is invalid.</exception>
+        public static string ToCsv(this DataTable dataTable, string delimiter = ",")
         {
-            throw new NotSupportedException("Cannot use \" as a delimiter as it is used in CSV qualification");
-        }
-    }
+            ValidateArguments(dataTable, delimiter);
 
-    private static HashSet<string> GetHeaders(DataTable dataTable)
-    {
-        var headers = new HashSet<string>();
-        foreach (DataColumn column in dataTable.Columns)
-        {
-            var header = column.Caption ?? column.ColumnName;
+            var outputBuilder = new StringBuilder();
 
-            header = header.Replace("\"", "\"\"", StringComparison.InvariantCulture);
+            var headers = GetHeaders(dataTable);
 
-            headers.Add($"\"{header}\"");
+            outputBuilder.AppendJoin(delimiter, headers).AppendLine();
+
+            return GetRows(dataTable, delimiter, outputBuilder);
         }
 
-        return headers;
-    }
-
-    private static string GetRows(DataTable dataTable, string delimiter, StringBuilder outputBuilder)
-    {
-        foreach (DataRow row in dataTable.Rows)
+        private static void ValidateArguments(DataTable dataTable, string delimiter)
         {
-            var cells = new string[row.ItemArray.Length];
-
-            for (var i = 0; i < row.ItemArray.Length; i++)
+            if (dataTable == null)
             {
-                var cellValue = row.ItemArray.ElementAt(i);
-
-                // If we have a format string, we can apply it here using string.Format();
-                var cellValueString = cellValue?.ToString();
-                cellValueString = cellValueString?.Replace("\"", "\"\"", StringComparison.InvariantCulture);
-
-                cells[i] = $"\"{cellValueString}\"";
+                throw new ArgumentNullException(nameof(dataTable));
             }
 
-            outputBuilder.AppendJoin(delimiter, cells).AppendLine();
+            if (delimiter == "\"")
+            {
+                throw new NotSupportedException("Cannot use \" as a delimiter as it is used in CSV qualification");
+            }
         }
 
-        return outputBuilder.ToString().TrimEnd(Environment.NewLine.ToCharArray());
+        private static HashSet<string> GetHeaders(DataTable dataTable)
+        {
+            var headers = new HashSet<string>();
+            foreach (DataColumn column in dataTable.Columns)
+            {
+                var header = column.Caption ?? column.ColumnName;
+
+                header = header.Replace("\"", "\"\"", StringComparison.InvariantCulture);
+
+                headers.Add($"\"{header}\"");
+            }
+
+            return headers;
+        }
+
+        private static string GetRows(DataTable dataTable, string delimiter, StringBuilder outputBuilder)
+        {
+            foreach (DataRow row in dataTable.Rows)
+            {
+                var cells = new string[row.ItemArray.Length];
+
+                for (var i = 0; i < row.ItemArray.Length; i++)
+                {
+                    var cellValue = row.ItemArray.ElementAt(i);
+
+                    // If we have a format string, we can apply it here using string.Format();
+                    var cellValueString = cellValue?.ToString();
+                    cellValueString = cellValueString?.Replace("\"", "\"\"", StringComparison.InvariantCulture);
+
+                    cells[i] = $"\"{cellValueString}\"";
+                }
+
+                outputBuilder.AppendJoin(delimiter, cells).AppendLine();
+            }
+
+            return outputBuilder.ToString().TrimEnd(Environment.NewLine.ToCharArray());
+        }
     }
 }

--- a/src/Audacia.Core/Extensions/DateTimeExtensions.cs
+++ b/src/Audacia.Core/Extensions/DateTimeExtensions.cs
@@ -2,197 +2,198 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Audacia.Core.Extensions;
-
-/// <summary>
-/// Extension methods for the type <see cref="DateTime"/>.
-/// </summary>
-public static class DateTimeExtensions
+namespace Audacia.Core.Extensions
 {
     /// <summary>
-    /// Returns a suffix depending on the input date (i.e. nd, rd, th).
+    /// Extension methods for the type <see cref="DateTime"/>.
     /// </summary>
-    /// <param name="date">The date.</param>
-    /// <returns>The suffix string.</returns>
-    public static string TwoLetterSuffix(this DateTime date)
+    public static class DateTimeExtensions
     {
-        var dayModTen = date.Day % 10;
-
-        if (dayModTen > 3 || date.Day >= 10 && date.Day <= 19 || dayModTen == 0)
+        /// <summary>
+        /// Returns a suffix depending on the input date (i.e. nd, rd, th).
+        /// </summary>
+        /// <param name="date">The date.</param>
+        /// <returns>The suffix string.</returns>
+        public static string TwoLetterSuffix(this DateTime date)
         {
-            return "th";
-        }
+            var dayModTen = date.Day % 10;
 
-        return dayModTen switch
-        {
-            1 => "st",
-            2 => "nd",
-            _ => "rd",
-        };
-    }
-
-    /// <summary>
-    /// If a month is longer than the requested month, will choose the last day of
-    /// the requested month instead of continuing into the start of the month after.
-    /// </summary>
-    /// <param name="date">The start date.</param>
-    /// <param name="months">The number of months to add.</param>
-    /// <returns>The resultant date.</returns>
-    public static DateTime AddJustMonths(this DateTime date, int months)
-    {
-        var firstDayOfTargetMonth = new DateTime(date.Year, date.Month, 1).AddMonths(months);
-        var lastDayofTargetMonth = DateTime.DaysInMonth(firstDayOfTargetMonth.Year, firstDayOfTargetMonth.Month);
-
-        var targetDay = date.Day > lastDayofTargetMonth ? lastDayofTargetMonth : date.Day;
-
-        return new DateTime(firstDayOfTargetMonth.Year, firstDayOfTargetMonth.Month, targetDay);
-    }
-
-    /// <summary>
-    /// Add business days to a date (does not support bank holidays).
-    /// </summary>
-    /// <param name="startDate">The start date.</param>
-    /// <param name="businessDays">The number of days to add.</param>
-    /// <returns>The resultant date.</returns>
-    public static DateTime AddBusinessDays(this DateTime startDate, double businessDays)
-    {
-        return AddBusinessDays(startDate, businessDays, Array.Empty<DateTime>());
-    }
-
-    /// <summary>
-    /// Add business days to a date (does not support bank holidays).
-    /// </summary>
-    /// <param name="startDate">The start date.</param>
-    /// <param name="businessDays">The number of days to add.</param>
-    /// <param name="skipDays">Days to skip (e.g. bank holidays).</param>
-    /// <returns>The resultant date.</returns>
-    public static DateTime AddBusinessDays(this DateTime startDate, double businessDays, IEnumerable<DateTime> skipDays)
-    {
-        if (skipDays == null)
-        {
-            skipDays = Array.Empty<DateTime>();
-        }
-
-        var dayOfWeek = (int)startDate.DayOfWeek;
-        var temp = businessDays + dayOfWeek + 1;
-
-        if (dayOfWeek != 0)
-        {
-            temp--;
-        }
-
-        var startDateWithWorkingDaysAdded = startDate.AddDays(Math.Floor(temp / 5) * 2 - dayOfWeek + temp - 2 * Convert.ToInt32(Math.Abs(temp % 5 - 0) < double.Epsilon));
-
-        return startDateWithWorkingDaysAdded.AddDays(skipDays.Count(bh => bh >= startDate && bh <= startDateWithWorkingDaysAdded));
-    }
-
-    /// <summary>
-    /// Determines whether or not the current date is a business day.
-    /// </summary>
-    /// <param name="date">The date to test.</param>
-    /// <returns>If <paramref name="date"/> is a business day.</returns>
-    public static bool IsBusinessDay(this DateTime date)
-    {
-        return IsBusinessDay(date, Array.Empty<DateTime>());
-    }
-
-    /// <summary>
-    /// Determines whether or not the current date is a business day.
-    /// </summary>
-    /// <param name="date">The date to test.</param>
-    /// <param name="skipDays">Days to skip (e.g. bank holidays).</param>
-    /// <returns>If <paramref name="date"/> is a business day.</returns>
-    public static bool IsBusinessDay(this DateTime date, IEnumerable<DateTime> skipDays)
-    {
-        if (skipDays == null)
-        {
-            skipDays = Array.Empty<DateTime>();
-        }
-
-        var weekendDays = new[] { DayOfWeek.Saturday, DayOfWeek.Sunday };
-
-        return !weekendDays.Contains(date.DayOfWeek) && !skipDays.Contains(date);
-    }
-
-    /// <summary>
-    /// Gets the business days between two dates (does not support bank holidays).
-    /// </summary>
-    /// <param name="startDate">The start date.</param>
-    /// <param name="endDate">The end date.</param>
-    /// <returns>The number of business days between.</returns>
-    public static double GetBusinessDaysUntil(this DateTime startDate, DateTime endDate)
-    {
-        return GetBusinessDaysUntil(startDate, endDate, Array.Empty<DateTime>());
-    }
-
-    /// <summary>
-    /// Gets the business days between two dates (does not support bank holidays).
-    /// </summary>
-    /// <param name="startDate">The start date.</param>
-    /// <param name="endDate">The end date.</param>
-    /// <param name="skipDays">Days to skip (e.g. bank holidays).</param>
-    /// <returns>The number of business days between.</returns>
-    public static double GetBusinessDaysUntil(this DateTime startDate, DateTime endDate, ICollection<DateTime> skipDays)
-    {
-        if (skipDays == null)
-        {
-            skipDays = Array.Empty<DateTime>();
-        }
-
-        var (firstDay, lastDay, isNegative) = GetBusinessDayDetails(startDate, endDate);
-
-        var businessDays = GetBusinessDays(false, skipDays, firstDay, lastDay);
-
-        return isNegative ? 0 - businessDays : businessDays;
-    }
-
-    /// <summary>
-    /// Gets the business days between two dates (does not support bank holidays).
-    /// </summary>
-    /// <param name="startDate">The start date.</param>
-    /// <param name="endDate">The end date.</param>
-    /// <param name="skipDays">Days to skip (e.g. bank holidays).</param>
-    /// <returns>The number of business days between.</returns>
-    public static double GetBusinessDaysUntilExclusive(this DateTime startDate, DateTime endDate, ICollection<DateTime> skipDays)
-    {
-        if (skipDays == null)
-        {
-            skipDays = Array.Empty<DateTime>();
-        }
-
-        var (firstDay, lastDay, isNegative) = GetBusinessDayDetails(startDate, endDate);
-
-        var businessDays = GetBusinessDays(true, skipDays, firstDay, lastDay);
-
-        return isNegative ? 0 - businessDays : businessDays;
-    }
-
-    private static (DateTime FirstDay, DateTime LastDay, bool IsNegative) GetBusinessDayDetails(DateTime startDate, DateTime endDate)
-    {
-        var (firstDay, lastDay, isNegative) = (startDate.Date, endDate.Date, false);
-
-        if (firstDay > lastDay)
-        {
-            (lastDay, firstDay) = (firstDay, lastDay);
-            isNegative = true;
-        }
-
-        return (firstDay, lastDay, isNegative);
-    }
-
-    private static int GetBusinessDays(bool exclusive, ICollection<DateTime> skipDays, DateTime firstDay, DateTime lastDay)
-    {
-        var businessDays = 0;
-
-        for (var date = firstDay; exclusive ? date < lastDay : date <= lastDay; date = date.AddDays(1))
-        {
-            if (date.DayOfWeek != DayOfWeek.Saturday && date.DayOfWeek != DayOfWeek.Sunday &&
-                !skipDays.Contains(date))
+            if (dayModTen > 3 || date.Day >= 10 && date.Day <= 19 || dayModTen == 0)
             {
-                businessDays++;
+                return "th";
             }
+
+            return dayModTen switch
+            {
+                1 => "st",
+                2 => "nd",
+                _ => "rd",
+            };
         }
 
-        return businessDays;
+        /// <summary>
+        /// If a month is longer than the requested month, will choose the last day of
+        /// the requested month instead of continuing into the start of the month after.
+        /// </summary>
+        /// <param name="date">The start date.</param>
+        /// <param name="months">The number of months to add.</param>
+        /// <returns>The resultant date.</returns>
+        public static DateTime AddJustMonths(this DateTime date, int months)
+        {
+            var firstDayOfTargetMonth = new DateTime(date.Year, date.Month, 1).AddMonths(months);
+            var lastDayofTargetMonth = DateTime.DaysInMonth(firstDayOfTargetMonth.Year, firstDayOfTargetMonth.Month);
+
+            var targetDay = date.Day > lastDayofTargetMonth ? lastDayofTargetMonth : date.Day;
+
+            return new DateTime(firstDayOfTargetMonth.Year, firstDayOfTargetMonth.Month, targetDay);
+        }
+
+        /// <summary>
+        /// Add business days to a date (does not support bank holidays).
+        /// </summary>
+        /// <param name="startDate">The start date.</param>
+        /// <param name="businessDays">The number of days to add.</param>
+        /// <returns>The resultant date.</returns>
+        public static DateTime AddBusinessDays(this DateTime startDate, double businessDays)
+        {
+            return AddBusinessDays(startDate, businessDays, Array.Empty<DateTime>());
+        }
+
+        /// <summary>
+        /// Add business days to a date (does not support bank holidays).
+        /// </summary>
+        /// <param name="startDate">The start date.</param>
+        /// <param name="businessDays">The number of days to add.</param>
+        /// <param name="skipDays">Days to skip (e.g. bank holidays).</param>
+        /// <returns>The resultant date.</returns>
+        public static DateTime AddBusinessDays(this DateTime startDate, double businessDays, IEnumerable<DateTime> skipDays)
+        {
+            if (skipDays == null)
+            {
+                skipDays = Array.Empty<DateTime>();
+            }
+
+            var dayOfWeek = (int)startDate.DayOfWeek;
+            var temp = businessDays + dayOfWeek + 1;
+
+            if (dayOfWeek != 0)
+            {
+                temp--;
+            }
+
+            var startDateWithWorkingDaysAdded = startDate.AddDays(Math.Floor(temp / 5) * 2 - dayOfWeek + temp - 2 * Convert.ToInt32(Math.Abs(temp % 5 - 0) < double.Epsilon));
+
+            return startDateWithWorkingDaysAdded.AddDays(skipDays.Count(bh => bh >= startDate && bh <= startDateWithWorkingDaysAdded));
+        }
+
+        /// <summary>
+        /// Determines whether or not the current date is a business day.
+        /// </summary>
+        /// <param name="date">The date to test.</param>
+        /// <returns>If <paramref name="date"/> is a business day.</returns>
+        public static bool IsBusinessDay(this DateTime date)
+        {
+            return IsBusinessDay(date, Array.Empty<DateTime>());
+        }
+
+        /// <summary>
+        /// Determines whether or not the current date is a business day.
+        /// </summary>
+        /// <param name="date">The date to test.</param>
+        /// <param name="skipDays">Days to skip (e.g. bank holidays).</param>
+        /// <returns>If <paramref name="date"/> is a business day.</returns>
+        public static bool IsBusinessDay(this DateTime date, IEnumerable<DateTime> skipDays)
+        {
+            if (skipDays == null)
+            {
+                skipDays = Array.Empty<DateTime>();
+            }
+
+            var weekendDays = new[] { DayOfWeek.Saturday, DayOfWeek.Sunday };
+
+            return !weekendDays.Contains(date.DayOfWeek) && !skipDays.Contains(date);
+        }
+
+        /// <summary>
+        /// Gets the business days between two dates (does not support bank holidays).
+        /// </summary>
+        /// <param name="startDate">The start date.</param>
+        /// <param name="endDate">The end date.</param>
+        /// <returns>The number of business days between.</returns>
+        public static double GetBusinessDaysUntil(this DateTime startDate, DateTime endDate)
+        {
+            return GetBusinessDaysUntil(startDate, endDate, Array.Empty<DateTime>());
+        }
+
+        /// <summary>
+        /// Gets the business days between two dates (does not support bank holidays).
+        /// </summary>
+        /// <param name="startDate">The start date.</param>
+        /// <param name="endDate">The end date.</param>
+        /// <param name="skipDays">Days to skip (e.g. bank holidays).</param>
+        /// <returns>The number of business days between.</returns>
+        public static double GetBusinessDaysUntil(this DateTime startDate, DateTime endDate, ICollection<DateTime> skipDays)
+        {
+            if (skipDays == null)
+            {
+                skipDays = Array.Empty<DateTime>();
+            }
+
+            var (firstDay, lastDay, isNegative) = GetBusinessDayDetails(startDate, endDate);
+
+            var businessDays = GetBusinessDays(false, skipDays, firstDay, lastDay);
+
+            return isNegative ? 0 - businessDays : businessDays;
+        }
+
+        /// <summary>
+        /// Gets the business days between two dates (does not support bank holidays).
+        /// </summary>
+        /// <param name="startDate">The start date.</param>
+        /// <param name="endDate">The end date.</param>
+        /// <param name="skipDays">Days to skip (e.g. bank holidays).</param>
+        /// <returns>The number of business days between.</returns>
+        public static double GetBusinessDaysUntilExclusive(this DateTime startDate, DateTime endDate, ICollection<DateTime> skipDays)
+        {
+            if (skipDays == null)
+            {
+                skipDays = Array.Empty<DateTime>();
+            }
+
+            var (firstDay, lastDay, isNegative) = GetBusinessDayDetails(startDate, endDate);
+
+            var businessDays = GetBusinessDays(true, skipDays, firstDay, lastDay);
+
+            return isNegative ? 0 - businessDays : businessDays;
+        }
+
+        private static (DateTime FirstDay, DateTime LastDay, bool IsNegative) GetBusinessDayDetails(DateTime startDate, DateTime endDate)
+        {
+            var (firstDay, lastDay, isNegative) = (startDate.Date, endDate.Date, false);
+
+            if (firstDay > lastDay)
+            {
+                (lastDay, firstDay) = (firstDay, lastDay);
+                isNegative = true;
+            }
+
+            return (firstDay, lastDay, isNegative);
+        }
+
+        private static int GetBusinessDays(bool exclusive, ICollection<DateTime> skipDays, DateTime firstDay, DateTime lastDay)
+        {
+            var businessDays = 0;
+
+            for (var date = firstDay; exclusive ? date < lastDay : date <= lastDay; date = date.AddDays(1))
+            {
+                if (date.DayOfWeek != DayOfWeek.Saturday && date.DayOfWeek != DayOfWeek.Sunday &&
+                    !skipDays.Contains(date))
+                {
+                    businessDays++;
+                }
+            }
+
+            return businessDays;
+        }
     }
 }

--- a/src/Audacia.Core/Extensions/EnumExtensions.cs
+++ b/src/Audacia.Core/Extensions/EnumExtensions.cs
@@ -1,78 +1,87 @@
 ﻿using System;
+using System.Data;
 
-namespace Audacia.Core.Extensions;
-
-/// <summary>
-/// Extension methods for the type <see cref="Enum"/>.
-/// </summary>
-public static class EnumExtensions
+namespace Audacia.Core.Extensions
 {
     /// <summary>
-    /// Returns the description attribute on an enumeration value, if there is no description attribute then returns the value to string.
+    /// Extension methods for the type <see cref="Enum"/>.
     /// </summary>
-    /// <typeparam name="TEnum">The enumeration type.</typeparam>
-    /// <param name="enumValue">The enumeration value.</param>
-    /// <returns>The description, falling back to ToString(), falling back to null if the supplied is not an enum.</returns>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1551:Method overload should call another overload", Justification = "Other 'overload' has different type parameters")]
-    public static string? ToEnumDescriptionString<TEnum>(this TEnum enumValue) where TEnum : struct
+    public static class EnumExtensions
     {
-        return typeof(TEnum).ToEnumDescriptionString(enumValue);
-    }
-
-    /// <summary>
-    /// Returns the description attribute on an enumeration value, if there is no description attribute then returns the value to string.
-    /// </summary>
-    /// <param name="type">The enumeration type.</param>
-    /// <param name="enumValue">The enumeration value.</param>
-    /// <returns>The description, falling back to ToString(), falling back to null if the supplied is not an enum.</returns>
-    /// <exception cref="NotSupportedException">Type has to be enumerable.</exception>
-    /// <exception cref="ArgumentNullException">All parameters are required and not nullable.</exception>
-    public static string? ToEnumDescriptionString(this Type type, object enumValue)
-    {
-        ValidateEnumDescription(type, enumValue);
-
-        var fieldInfo = enumValue.GetType().GetField(enumValue!.ToString() ?? string.Empty);
-
-        return fieldInfo != null ? fieldInfo.GetDataAnnotationDisplayName() : enumValue?.ToString();
-    }
-
-    /// <summary>
-    /// Attempts to parse a string to the equivalent constant value from the ennumeration type TEnum, using firstly
-    /// the property name and then the description attribute if present. Outputs the parsed value and returns a 
-    /// boolean value representing whether the action succeeded.
-    /// </summary>
-    /// <typeparam name="TEnum">The ennumeration type to which to parse the string.</typeparam>
-    /// <param name="value">The string to convert.</param>
-    /// <param name="result">The parsed value. If unsuccessful, the default value of the underlying TEnum.</param>
-    /// <returns>A boolean value representing the success of the operation.</returns>
-    public static bool TryParseDescription<TEnum>(this string value, out TEnum result)
-        where TEnum : struct
-    {
-        if (Enum.TryParse(value, out result))
+        /// <summary>
+        /// Returns the description attribute on an enumeration value, if there is no description attribute then returns the value to string.
+        /// </summary>
+        /// <typeparam name="TEnum">The enumeration type.</typeparam>
+        /// <param name="enumValue">The enumeration value.</param>
+        /// <returns>The description, falling back to ToString(), falling back to null if the supplied is not an enum.</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1551:Method overload should call another overload", Justification = "Other 'overload' has different type parameters")]
+        public static string? ToEnumDescriptionString<TEnum>(this TEnum enumValue) where TEnum : struct
         {
-            return true;
+            return typeof(TEnum).ToEnumDescriptionString(enumValue);
         }
 
-        foreach (var enumValue in (TEnum[])Enum.GetValues(typeof(TEnum)))
+        /// <summary>
+        /// Returns the description attribute on an enumeration value, if there is no description attribute then returns the value to string.
+        /// </summary>
+        /// <param name="type">The enumeration type.</param>
+        /// <param name="enumValue">The enumeration value.</param>
+        /// <returns>The description, falling back to ToString(), falling back to null if the supplied is not an enum.</returns>
+        /// <exception cref="NotSupportedException">Type has to be enumerable.</exception>
+        /// <exception cref="ArgumentNullException">All parameters are required and not nullable.</exception>
+        public static string? ToEnumDescriptionString(this Type type, object enumValue)
         {
-            if (string.Equals(enumValue.ToEnumDescriptionString(), value, StringComparison.OrdinalIgnoreCase))
+            ValidateEnumDescription(type, enumValue);
+
+            var fieldInfo = enumValue.GetType().GetField(enumValue!.ToString() ?? string.Empty);
+
+            return fieldInfo != null ? fieldInfo.GetDataAnnotationDisplayName() : enumValue?.ToString();
+        }
+
+        /// <summary>
+        /// Attempts to parse a string to the equivalent constant value from the ennumeration type TEnum, using firstly
+        /// the property name and then the description attribute if present. Outputs the parsed value and returns a 
+        /// boolean value representing whether the action succeeded.
+        /// </summary>
+        /// <typeparam name="TEnum">The ennumeration type to which to parse the string.</typeparam>
+        /// <param name="value">The string to convert.</param>
+        /// <param name="result">The parsed value. If unsuccessful, the default value of the underlying TEnum.</param>
+        /// <returns>A boolean value representing the success of the operation.</returns>
+        public static bool TryParseDescription<TEnum>(this string value, out TEnum result)
+            where TEnum : struct
+        {
+            if (Enum.TryParse(value, out result))
             {
-                result = enumValue;
                 return true;
             }
+
+            foreach (var enumValue in (TEnum[])Enum.GetValues(typeof(TEnum)))
+            {
+                if (string.Equals(enumValue.ToEnumDescriptionString(), value, StringComparison.OrdinalIgnoreCase))
+                {
+                    result = enumValue;
+                    return true;
+                }
+            }
+
+            return false;
         }
 
-        return false;
-    }
-
-    private static void ValidateEnumDescription(Type type, object enumValue)
-    {
-        ArgumentNullException.ThrowIfNull(type);
-        ArgumentNullException.ThrowIfNull(enumValue);
-
-        if (!type.IsEnum)
+        private static void ValidateEnumDescription(Type type, object enumValue)
         {
-            throw new NotSupportedException("An Enumeration type is required.");
+            if (type == null)
+            {
+                throw new ArgumentNullException(nameof(type));
+            }
+
+            if (enumValue == null)
+            {
+                throw new ArgumentNullException(nameof(enumValue));
+            }
+
+            if (!type.IsEnum)
+            {
+                throw new NotSupportedException("An Enumeration type is required.");
+            }
         }
     }
 }

--- a/src/Audacia.Core/Extensions/EnumerableExtensions.cs
+++ b/src/Audacia.Core/Extensions/EnumerableExtensions.cs
@@ -1,38 +1,39 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 
-namespace Audacia.Core.Extensions;
-
-/// <summary>
-/// Extension methods for the type <see cref="Enumerable"/>.
-/// </summary>
-public static class EnumerableExtensions
+namespace Audacia.Core.Extensions
 {
     /// <summary>
-    /// Groups a collection by a the <typeparamref name="T"/> type.
+    /// Extension methods for the type <see cref="Enumerable"/>.
     /// </summary>
-    /// <typeparam name="T">The type to group by.</typeparam>
-    /// <param name="enumerable">The collection to group.</param>
-    /// <param name="number">The number of groups.</param>
-    /// <returns>A <see cref="IEnumerable{T}"/>, grouped by <typeparamref name="T"/>.</returns>
-    public static IEnumerable<IGrouping<int, T>> GroupsOf<T>(this IEnumerable<T> enumerable, int number)
+    public static class EnumerableExtensions
     {
-        return enumerable.Select((item, index) => new { item, index })
-            .GroupBy(entry => entry.index / number, entry => entry.item)
-            .ToList();
-    }
+        /// <summary>
+        /// Groups a collection by a the <typeparamref name="T"/> type.
+        /// </summary>
+        /// <typeparam name="T">The type to group by.</typeparam>
+        /// <param name="enumerable">The collection to group.</param>
+        /// <param name="number">The number of groups.</param>
+        /// <returns>A <see cref="IEnumerable{T}"/>, grouped by <typeparamref name="T"/>.</returns>
+        public static IEnumerable<IGrouping<int, T>> GroupsOf<T>(this IEnumerable<T> enumerable, int number)
+        {
+            return enumerable.Select((item, index) => new { item, index })
+                .GroupBy(entry => entry.index / number, entry => entry.item)
+                .ToList();
+        }
 
-    /// <summary>
-    /// Converts a grouped collection to a dictionary.
-    /// </summary>
-    /// <typeparam name="TKey">The group key.</typeparam>
-    /// <typeparam name="TValue">The group values.</typeparam>
-    /// <param name="grouping">The grouped collection.</param>
-    /// <returns>A dictionary, whose key is the groups key, and values are the values for that key.</returns>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Member Design", "AV1130:Return type in method signature should be an interface to an unchangeable collection", Justification = "Limited to dictionaries.")]
-    public static IDictionary<TKey, List<TValue>> ToDictionary<TKey, TValue>(
-        this IEnumerable<IGrouping<TKey, TValue>> grouping) where TKey : notnull
-    {
-        return grouping.ToDictionary(group => group.Key, group => group.ToList());
+        /// <summary>
+        /// Converts a grouped collection to a dictionary.
+        /// </summary>
+        /// <typeparam name="TKey">The group key.</typeparam>
+        /// <typeparam name="TValue">The group values.</typeparam>
+        /// <param name="grouping">The grouped collection.</param>
+        /// <returns>A dictionary, whose key is the groups key, and values are the values for that key.</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Member Design", "AV1130:Return type in method signature should be an interface to an unchangeable collection", Justification = "Limited to dictionaries.")]
+        public static IDictionary<TKey, List<TValue>> ToDictionary<TKey, TValue>(
+            this IEnumerable<IGrouping<TKey, TValue>> grouping) where TKey : notnull
+        {
+            return grouping.ToDictionary(group => group.Key, group => group.ToList());
+        }
     }
 }

--- a/src/Audacia.Core/Extensions/ExpressionExtensions.cs
+++ b/src/Audacia.Core/Extensions/ExpressionExtensions.cs
@@ -5,296 +5,324 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 
-namespace Audacia.Core.Extensions;
-
-/// <summary>
-/// Extension methods for the type <see cref="Expression"/>.
-/// </summary>
-public static class ExpressionExtensions
+namespace Audacia.Core.Extensions
 {
     /// <summary>
-    /// Return property information for a lambda property expression.
+    /// Extension methods for the type <see cref="Expression"/>.
     /// </summary>
-    /// <param name="propertyExpression">A lambda property expression.</param>
-    /// <returns>Property information for <paramref name="propertyExpression"/>.</returns>
-    /// <exception cref="ArgumentException"><paramref name="propertyExpression"/> is not a lambda expression.</exception>
-    /// <exception cref="InvalidOperationException"><paramref name="propertyExpression"/> does not have a declaring type.</exception>
-    /// <exception cref="ArgumentNullException"><paramref name="propertyExpression"/> is null.</exception>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1551:Method overload should call another overload", Justification = "This is called from another overload.")]
-    public static PropertyInfo? GetPropertyInfo(Expression propertyExpression)
+    public static class ExpressionExtensions
     {
-        ArgumentNullException.ThrowIfNull(propertyExpression);
-
-        if (propertyExpression.NodeType != ExpressionType.Lambda)
+        /// <summary>
+        /// Return property information for a lambda property expression.
+        /// </summary>
+        /// <param name="propertyExpression">A lambda property expression.</param>
+        /// <returns>Property information for <paramref name="propertyExpression"/>.</returns>
+        /// <exception cref="ArgumentException"><paramref name="propertyExpression"/> is not a lambda expression.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="propertyExpression"/> does not have a declaring type.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="propertyExpression"/> is null.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1551:Method overload should call another overload", Justification = "This is called from another overload.")]
+        public static PropertyInfo? GetPropertyInfo(Expression propertyExpression)
         {
-            throw new ArgumentException("Selector must be lambda expression", nameof(propertyExpression));
-        }
-
-        var lambda = (LambdaExpression)propertyExpression;
-
-        var memberExpression = ExtractMemberExpression(lambda.Body);
-
-        if (memberExpression == null)
-        {
-            throw new ArgumentException("Selector must be member access expression", nameof(propertyExpression));
-        }
-
-        if (memberExpression.Member.DeclaringType == null)
-        {
-            throw new InvalidOperationException("Property does not have declaring type");
-        }
-
-        return memberExpression.Member.DeclaringType.GetProperty(memberExpression.Member.Name);
-    }
-
-    /// <summary>
-    /// Return property information for a lambda property expression.
-    /// </summary>
-    /// <typeparam name="T">The type of the property information.</typeparam>
-    /// <param name="obj">Source object to return type argument implicitly.</param>
-    /// <param name="propertyExpression">A lambda property expression.</param>
-    /// <returns>Property information for <paramref name="propertyExpression"/>.</returns>
-    /// <exception cref="ArgumentException"><paramref name="propertyExpression"/> is not a lambda expression.</exception>
-    /// <exception cref="InvalidOperationException"><paramref name="propertyExpression"/> does not have a declaring type.</exception>
-    /// <exception cref="ArgumentNullException"><paramref name="propertyExpression"/> is null.</exception>
-    public static PropertyInfo? GetPropertyInfo<T>(this T obj, Expression<Func<T, object>> propertyExpression)
-    {
-        //Overloaded so allow object specific property access and allow implicit type argument
-        return GetPropertyInfo(propertyExpression);
-    }
-
-    private static MemberExpression ExtractMemberExpression(Expression expression)
-    {
-        // ReSharper disable once SwitchStatementMissingSomeCases
-        switch (expression.NodeType)
-        {
-            case ExpressionType.MemberAccess:
-                return (MemberExpression)expression;
-            case ExpressionType.Convert:
-                var operand = ((UnaryExpression)expression).Operand;
-                return ExtractMemberExpression(operand);
-            default:
-                return default!;
-        }
-    }
-
-    /// <summary>
-    /// Convert generic type argument in an expression to a specified type.
-    /// </summary>
-    /// <typeparam name="TSource">The generic type.</typeparam>
-    /// <typeparam name="TTarget">The type to replace <typeparamref name="TSource"/>.</typeparam>
-    /// <typeparam name="TResult">The returned value.</typeparam>
-    /// <param name="root">The original expression.</param>
-    /// <returns>An expression with <typeparamref name="TSource"/> replaced with <typeparamref name="TTarget"/>.</returns>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1551:Method overload should call another overload", Justification = "Other method with same name isn't the same functionality.")]
-    public static Expression<Func<TTarget, TResult>> ConvertGenericTypeArgument<TSource, TTarget, TResult>(
-        this Expression<Func<TSource, TResult>> root)
-    {
-        var visitor = new ParameterReplacer(typeof(TSource), typeof(TTarget));
-        return (visitor.Visit(root) as Expression<Func<TTarget, TResult>>) ?? default!;
-    }
-
-    /// <summary>
-    /// Convert generic type argument in an expression to a specified type.
-    /// </summary>
-    /// <typeparam name="TSource">The generic type.</typeparam>
-    /// <typeparam name="TResult">The returned value.</typeparam>
-    /// <param name="root">The original expression.</param>
-    /// <param name="targetType">The type to replace <typeparamref name="TSource"/>.</param>
-    /// <returns>An expression with <typeparamref name="TSource"/> replaced with <paramref name="targetType"/>.</returns>
-    public static LambdaExpression ConvertGenericTypeArgument<TSource, TResult>(
-        this Expression<Func<TSource, TResult>> root, Type targetType)
-    {
-        var visitor = new ParameterReplacer(typeof(TSource), targetType);
-        var expression = visitor.Visit(root);
-        return (expression as LambdaExpression) ?? default!;
-    }
-
-    /// <summary>
-    /// Compiles an expression.
-    /// </summary>
-    /// <typeparam name="T">The type of argument.</typeparam>
-    /// <typeparam name="TResult">The type of the returned value.</typeparam>
-    /// <param name="expression">The expression to compile.</param>
-    /// <param name="arg">An argument provided for the expression.</param>
-    /// <returns><typeparamref name="TResult"/> result from the <paramref name="expression"/>."/>.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="expression"/> is null.</exception>
-    public static TResult Execute<T, TResult>(this Expression<Func<T, TResult>> expression, T arg)
-    {
-        return (expression ?? throw new ArgumentNullException(nameof(expression), "Expression cannot be null")).Compile()(arg);
-    }
-
-    /// <summary>
-    /// Compiles an expression.
-    /// </summary>
-    /// <typeparam name="T">The type of argument.</typeparam>
-    /// <param name="expression">The expression to compile.</param>
-    /// <param name="arg">An argument provided for the expression.</param>
-    /// <exception cref="ArgumentNullException"><paramref name="expression"/> is null.</exception>
-    public static void Perform<T>(this Expression<Action<T>> expression, T arg)
-    {
-        (expression ?? throw new ArgumentNullException(nameof(expression), "Expression cannot be null")).Compile()(arg);
-    }
-
-    /// <summary>
-    /// Combines the first predicate with the second using the logical "and".
-    /// </summary>
-    /// <param name="first">The source expression.</param>
-    /// <param name="second">The expression to join on to <paramref name="first"/>.</param>
-    /// <typeparam name="T">The input type.</typeparam>
-    /// <returns>An expression combining <paramref name="first"/> and <paramref name="second"/>.</returns>
-    public static Expression<Func<T, bool>> And<T>(
-        this Expression<Func<T, bool>> first,
-        Expression<Func<T, bool>> second)
-    {
-        return first.Compose(second, Expression.AndAlso);
-    }
-
-    /// <summary>
-    /// Combines the first predicate with the second using the logical "or".
-    /// </summary>
-    /// <param name="first">The source expression.</param>
-    /// <param name="second">The expression to join on to <paramref name="first"/>.</param>
-    /// <typeparam name="T">The input type.</typeparam>
-    /// <returns>An expression combining <paramref name="first"/> or <paramref name="second"/>.</returns>
-    public static Expression<Func<T, bool>> Or<T>(
-        this Expression<Func<T, bool>> first,
-        Expression<Func<T, bool>> second)
-    {
-        return first.Compose(second, Expression.OrElse);
-    }
-
-    /// <summary>
-    /// Negates the predicate.
-    /// </summary>
-    /// <param name="expression">The source expression.</param>
-    /// <typeparam name="T">The input type.</typeparam>
-    /// <returns>An expression with a negated prediction.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="expression"/> is null.</exception>
-    public static Expression<Func<T, bool>> Not<T>(this Expression<Func<T, bool>> expression)
-    {
-        ArgumentNullException.ThrowIfNull(expression);
-
-        var negated = Expression.Not(expression.Body);
-        return Expression.Lambda<Func<T, bool>>(negated, expression.Parameters);
-    }
-
-    /// <summary>
-    /// Apply the <paramref name="second"/> expression to the result of this expression.
-    /// </summary>
-    /// <typeparam name="TIn">The input type of the source expression.</typeparam>
-    /// <typeparam name="TInter">The output type of the source expression and the input type of the return expression.</typeparam>
-    /// <typeparam name="TOut">The output type of the return expression.</typeparam>
-    /// <param name="first">The source expression.</param>
-    /// <param name="second">The second expression to apply to the result of the first.</param>
-    /// <returns>An expression to run <paramref name="second"/> after <paramref name="first"/> expression.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="first"/> or <paramref name="second"/> is null.</exception>
-    public static Expression<Func<TIn, TOut>> Then<TIn, TInter, TOut>(this Expression<Func<TIn, TInter>> first, Expression<Func<TInter, TOut>> second)
-    {
-        ArgumentNullException.ThrowIfNull(first);
-        ArgumentNullException.ThrowIfNull(second);
-
-        //Map the parameters of the second expression to the body of the first
-        var replacements = second.Parameters
-            .Select(p => new { parameter = p, replacement = first.Body })
-            .ToDictionary(p => (Expression)p.parameter, p => p.replacement);
-
-        //Replace the parameters of the second Expression with the body of the first
-        var secondBody = ParameterRebinder.ReplaceParameters(replacements, second.Body);
-        return Expression.Lambda<Func<TIn, TOut>>(secondBody, first.Parameters);
-    }
-
-    /// <summary>
-    /// Merges two expressions into one.
-    /// </summary>
-    /// <typeparam name="T">The input type of the merging expressions.</typeparam>
-    /// <param name="first">The source expression.</param>
-    /// <param name="second">The expression to merge with <paramref name="first"/>.</param>
-    /// <param name="merge">How the expressions are merged together.</param>
-    /// <returns>The merged expression of <paramref name="first"/> and <paramref name="second"/>.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="first"/> or <paramref name="second"/> is null.</exception>
-    public static Expression<T> Compose<T>(this Expression<T> first, Expression<T> second,
-        Func<Expression, Expression, Expression> merge)
-    {
-        ArgumentNullException.ThrowIfNull(first);
-        ArgumentNullException.ThrowIfNull(second);
-        ArgumentNullException.ThrowIfNull(merge);
-
-        // zip parameters (map from parameters of second to parameters of first)
-        var map = first.Parameters
-            .Select((f, i) => new { first = (Expression)f, second = (Expression)second.Parameters[i] })
-            .ToDictionary(p => p.second, p => p.first);
-
-        // replace parameters in the second lambda expression with the parameters in the first
-        var secondBody = ParameterRebinder.ReplaceParameters(map, second.Body);
-
-        // create a merged lambda expression with parameters from the first expression
-        return Expression.Lambda<T>(merge(first.Body, secondBody), first.Parameters);
-    }
-
-    private class ParameterRebinder : ExpressionVisitor
-    {
-        private readonly IDictionary<Expression, Expression> _map;
-
-        private ParameterRebinder(Dictionary<Expression, Expression> map)
-        {
-            _map = map ?? new Dictionary<Expression, Expression>();
-        }
-
-        public static Expression ReplaceParameters(
-            Dictionary<Expression, Expression> map,
-            Expression exp)
-        {
-            return new ParameterRebinder(map).Visit(exp);
-        }
-
-        protected override Expression VisitParameter(ParameterExpression p)
-        {
-            return _map.TryGetValue(p, out var replacement)
-                ? replacement
-                : base.VisitParameter(p);
-        }
-    }
-
-    private class ParameterReplacer : ExpressionVisitor
-    {
-        private readonly Type _source = default!;
-        private readonly Type _target = default!;
-        private ReadOnlyCollection<ParameterExpression> _parameters = default!;
-
-        public ParameterReplacer(Type source, Type target)
-        {
-            _source = source;
-            _target = target;
-        }
-
-        protected override Expression VisitParameter(ParameterExpression node)
-        {
-            return _parameters?.FirstOrDefault(p => p.Name == node.Name) ??
-                   (node.Type == _source ? Expression.Parameter(_target, node.Name) : node);
-        }
-
-        protected override Expression VisitLambda<T>(Expression<T> node)
-        {
-            _parameters = VisitAndConvert(node.Parameters, nameof(VisitLambda));
-            return Expression.Lambda(Visit(node.Body), _parameters);
-        }
-
-        protected override Expression VisitMember(MemberExpression node)
-        {
-            ArgumentNullException.ThrowIfNull(node);
-
-            if (node.Member.DeclaringType == _source)
+            if (propertyExpression == null)
             {
-                var expression = Visit(node?.Expression);
-
-                if (expression != null)
-                {
-                    Expression.Property(expression, node!.Member.Name);
-                }
+                throw new ArgumentNullException(nameof(propertyExpression));
             }
 
-            return base.VisitMember(node!);
+            if (propertyExpression.NodeType != ExpressionType.Lambda)
+            {
+                throw new ArgumentException("Selector must be lambda expression", nameof(propertyExpression));
+            }
+
+            var lambda = (LambdaExpression)propertyExpression;
+
+            var memberExpression = ExtractMemberExpression(lambda.Body);
+
+            if (memberExpression == null)
+            {
+                throw new ArgumentException("Selector must be member access expression", nameof(propertyExpression));
+            }
+
+            if (memberExpression.Member.DeclaringType == null)
+            {
+                throw new InvalidOperationException("Property does not have declaring type");
+            }
+
+            return memberExpression.Member.DeclaringType.GetProperty(memberExpression.Member.Name);
+        }
+
+        /// <summary>
+        /// Return property information for a lambda property expression.
+        /// </summary>
+        /// <typeparam name="T">The type of the property information.</typeparam>
+        /// <param name="obj">Source object to return type argument implicitly.</param>
+        /// <param name="propertyExpression">A lambda property expression.</param>
+        /// <returns>Property information for <paramref name="propertyExpression"/>.</returns>
+        /// <exception cref="ArgumentException"><paramref name="propertyExpression"/> is not a lambda expression.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="propertyExpression"/> does not have a declaring type.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="propertyExpression"/> is null.</exception>
+        public static PropertyInfo? GetPropertyInfo<T>(this T obj, Expression<Func<T, object>> propertyExpression)
+        {
+            //Overloaded so allow object specific property access and allow implicit type argument
+            return GetPropertyInfo(propertyExpression);
+        }
+
+        private static MemberExpression ExtractMemberExpression(Expression expression)
+        {
+            // ReSharper disable once SwitchStatementMissingSomeCases
+            switch (expression.NodeType)
+            {
+                case ExpressionType.MemberAccess:
+                    return (MemberExpression)expression;
+                case ExpressionType.Convert:
+                    var operand = ((UnaryExpression)expression).Operand;
+                    return ExtractMemberExpression(operand);
+                default:
+                    return default!;
+            }
+        }
+
+        /// <summary>
+        /// Convert generic type argument in an expression to a specified type.
+        /// </summary>
+        /// <typeparam name="TSource">The generic type.</typeparam>
+        /// <typeparam name="TTarget">The type to replace <typeparamref name="TSource"/>.</typeparam>
+        /// <typeparam name="TResult">The returned value.</typeparam>
+        /// <param name="root">The original expression.</param>
+        /// <returns>An expression with <typeparamref name="TSource"/> replaced with <typeparamref name="TTarget"/>.</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1551:Method overload should call another overload", Justification = "Other method with same name isn't the same functionality.")]
+        public static Expression<Func<TTarget, TResult>> ConvertGenericTypeArgument<TSource, TTarget, TResult>(
+            this Expression<Func<TSource, TResult>> root)
+        {
+            var visitor = new ParameterReplacer(typeof(TSource), typeof(TTarget));
+            return (visitor.Visit(root) as Expression<Func<TTarget, TResult>>) ?? default!;
+        }
+
+        /// <summary>
+        /// Convert generic type argument in an expression to a specified type.
+        /// </summary>
+        /// <typeparam name="TSource">The generic type.</typeparam>
+        /// <typeparam name="TResult">The returned value.</typeparam>
+        /// <param name="root">The original expression.</param>
+        /// <param name="targetType">The type to replace <typeparamref name="TSource"/>.</param>
+        /// <returns>An expression with <typeparamref name="TSource"/> replaced with <paramref name="targetType"/>.</returns>
+        public static LambdaExpression ConvertGenericTypeArgument<TSource, TResult>(
+            this Expression<Func<TSource, TResult>> root, Type targetType)
+        {
+            var visitor = new ParameterReplacer(typeof(TSource), targetType);
+            var expression = visitor.Visit(root);
+            return (expression as LambdaExpression) ?? default!;
+        }
+
+        /// <summary>
+        /// Compiles an expression.
+        /// </summary>
+        /// <typeparam name="T">The type of argument.</typeparam>
+        /// <typeparam name="TResult">The type of the returned value.</typeparam>
+        /// <param name="expression">The expression to compile.</param>
+        /// <param name="arg">An argument provided for the expression.</param>
+        /// <returns><typeparamref name="TResult"/> result from the <paramref name="expression"/>."/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="expression"/> is null.</exception>
+        public static TResult Execute<T, TResult>(this Expression<Func<T, TResult>> expression, T arg)
+        {
+            return (expression ?? throw new ArgumentNullException(nameof(expression), "Expression cannot be null")).Compile()(arg);
+        }
+
+        /// <summary>
+        /// Compiles an expression.
+        /// </summary>
+        /// <typeparam name="T">The type of argument.</typeparam>
+        /// <param name="expression">The expression to compile.</param>
+        /// <param name="arg">An argument provided for the expression.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="expression"/> is null.</exception>
+        public static void Perform<T>(this Expression<Action<T>> expression, T arg)
+        {
+            (expression ?? throw new ArgumentNullException(nameof(expression), "Expression cannot be null")).Compile()(arg);
+        }
+
+        /// <summary>
+        /// Combines the first predicate with the second using the logical "and".
+        /// </summary>
+        /// <param name="first">The source expression.</param>
+        /// <param name="second">The expression to join on to <paramref name="first"/>.</param>
+        /// <typeparam name="T">The input type.</typeparam>
+        /// <returns>An expression combining <paramref name="first"/> and <paramref name="second"/>.</returns>
+        public static Expression<Func<T, bool>> And<T>(
+            this Expression<Func<T, bool>> first,
+            Expression<Func<T, bool>> second)
+        {
+            return first.Compose(second, Expression.AndAlso);
+        }
+
+        /// <summary>
+        /// Combines the first predicate with the second using the logical "or".
+        /// </summary>
+        /// <param name="first">The source expression.</param>
+        /// <param name="second">The expression to join on to <paramref name="first"/>.</param>
+        /// <typeparam name="T">The input type.</typeparam>
+        /// <returns>An expression combining <paramref name="first"/> or <paramref name="second"/>.</returns>
+        public static Expression<Func<T, bool>> Or<T>(
+            this Expression<Func<T, bool>> first,
+            Expression<Func<T, bool>> second)
+        {
+            return first.Compose(second, Expression.OrElse);
+        }
+
+        /// <summary>
+        /// Negates the predicate.
+        /// </summary>
+        /// <param name="expression">The source expression.</param>
+        /// <typeparam name="T">The input type.</typeparam>
+        /// <returns>An expression with a negated prediction.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="expression"/> is null.</exception>
+        public static Expression<Func<T, bool>> Not<T>(this Expression<Func<T, bool>> expression)
+        {
+            if (expression == null)
+            {
+                throw new ArgumentNullException(nameof(expression));
+            }
+
+            var negated = Expression.Not(expression.Body);
+            return Expression.Lambda<Func<T, bool>>(negated, expression.Parameters);
+        }
+
+        /// <summary>
+        /// Apply the <paramref name="second"/> expression to the result of this expression.
+        /// </summary>
+        /// <typeparam name="TIn">The input type of the source expression.</typeparam>
+        /// <typeparam name="TInter">The output type of the source expression and the input type of the return expression.</typeparam>
+        /// <typeparam name="TOut">The output type of the return expression.</typeparam>
+        /// <param name="first">The source expression.</param>
+        /// <param name="second">The second expression to apply to the result of the first.</param>
+        /// <returns>An expression to run <paramref name="second"/> after <paramref name="first"/> expression.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="first"/> or <paramref name="second"/> is null.</exception>
+        public static Expression<Func<TIn, TOut>> Then<TIn, TInter, TOut>(this Expression<Func<TIn, TInter>> first, Expression<Func<TInter, TOut>> second)
+        {
+            if (first == null)
+            {
+                throw new ArgumentNullException(nameof(first));
+            }
+
+            if (second == null)
+            {
+                throw new ArgumentNullException(nameof(second));
+            }
+
+            //Map the parameters of the second expression to the body of the first
+            var replacements = second.Parameters
+                .Select(p => new { parameter = p, replacement = first.Body })
+                .ToDictionary(p => (Expression)p.parameter, p => p.replacement);
+
+            //Replace the parameters of the second Expression with the body of the first
+            var secondBody = ParameterRebinder.ReplaceParameters(replacements, second.Body);
+            return Expression.Lambda<Func<TIn, TOut>>(secondBody, first.Parameters);
+        }
+
+        /// <summary>
+        /// Merges two expressions into one.
+        /// </summary>
+        /// <typeparam name="T">The input type of the merging expressions.</typeparam>
+        /// <param name="first">The source expression.</param>
+        /// <param name="second">The expression to merge with <paramref name="first"/>.</param>
+        /// <param name="merge">How the expressions are merged together.</param>
+        /// <returns>The merged expression of <paramref name="first"/> and <paramref name="second"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="first"/> or <paramref name="second"/> is null.</exception>
+        public static Expression<T> Compose<T>(this Expression<T> first, Expression<T> second,
+            Func<Expression, Expression, Expression> merge)
+        {
+            if (first == null)
+            {
+                throw new ArgumentNullException(nameof(first));
+            }
+
+            if (second == null)
+            {
+                throw new ArgumentNullException(nameof(second));
+            }
+
+            if (merge == null)
+            {
+                throw new ArgumentNullException(nameof(merge));
+            }
+
+            // zip parameters (map from parameters of second to parameters of first)
+            var map = first.Parameters
+                .Select((f, i) => new { first = (Expression)f, second = (Expression)second.Parameters[i] })
+                .ToDictionary(p => p.second, p => p.first);
+
+            // replace parameters in the second lambda expression with the parameters in the first
+            var secondBody = ParameterRebinder.ReplaceParameters(map, second.Body);
+
+            // create a merged lambda expression with parameters from the first expression
+            return Expression.Lambda<T>(merge(first.Body, secondBody), first.Parameters);
+        }
+
+        private class ParameterRebinder : ExpressionVisitor
+        {
+            private readonly IDictionary<Expression, Expression> _map;
+
+            private ParameterRebinder(Dictionary<Expression, Expression> map)
+            {
+                _map = map ?? new Dictionary<Expression, Expression>();
+            }
+
+            public static Expression ReplaceParameters(
+                Dictionary<Expression, Expression> map,
+                Expression exp)
+            {
+                return new ParameterRebinder(map).Visit(exp);
+            }
+
+            protected override Expression VisitParameter(ParameterExpression p)
+            {
+                return _map.TryGetValue(p, out var replacement)
+                    ? replacement
+                    : base.VisitParameter(p);
+            }
+        }
+
+        private class ParameterReplacer : ExpressionVisitor
+        {
+            private readonly Type _source = default!;
+            private readonly Type _target = default!;
+            private ReadOnlyCollection<ParameterExpression> _parameters = default!;
+
+            public ParameterReplacer(Type source, Type target)
+            {
+                _source = source;
+                _target = target;
+            }
+
+            protected override Expression VisitParameter(ParameterExpression node)
+            {
+                return _parameters?.FirstOrDefault(p => p.Name == node.Name) ??
+                       (node.Type == _source ? Expression.Parameter(_target, node.Name) : node);
+            }
+
+            protected override Expression VisitLambda<T>(Expression<T> node)
+            {
+                _parameters = VisitAndConvert(node.Parameters, nameof(VisitLambda));
+                return Expression.Lambda(Visit(node.Body), _parameters);
+            }
+
+            protected override Expression VisitMember(MemberExpression node)
+            {
+                if (node == null)
+                {
+                    throw new ArgumentNullException(nameof(node));
+                }
+
+                if (node.Member.DeclaringType == _source)
+                {
+                    var expression = Visit(node?.Expression);
+
+                    if (expression != null)
+                    {
+                        Expression.Property(expression, node!.Member.Name);
+                    }
+                }
+
+                return base.VisitMember(node!);
+            }
         }
     }
 }

--- a/src/Audacia.Core/Extensions/FuncExtensions.cs
+++ b/src/Audacia.Core/Extensions/FuncExtensions.cs
@@ -1,74 +1,75 @@
 ﻿using System;
 using System.Collections.Concurrent;
 
-namespace Audacia.Core.Extensions;
-
-/// <summary>
-/// Extension methods for the type <see cref="Func{T, TResult}"/>.
-/// </summary>
-public static class FuncExtensions
+namespace Audacia.Core.Extensions
 {
     /// <summary>
-    /// Memoize the results of a function. 
+    /// Extension methods for the type <see cref="Func{T, TResult}"/>.
     /// </summary>
-    /// <typeparam name="T1">The type of the argument.</typeparam>
-    /// <typeparam name="TResult">The type of the result.</typeparam>
-    /// <param name="sourceFunction">The function to memoize.</param>
-    /// <returns>The results of the function, or a cached version of it if it has run before with the same argument.</returns>
-    public static Func<T1, TResult> Memoize<T1, TResult>(this Func<T1, TResult> sourceFunction) where T1 : notnull
+    public static class FuncExtensions
     {
-        var cache = new ConcurrentDictionary<T1, TResult>();
-        return arg => cache.GetOrAdd(arg, sourceFunction);
-    }
+        /// <summary>
+        /// Memoize the results of a function. 
+        /// </summary>
+        /// <typeparam name="T1">The type of the argument.</typeparam>
+        /// <typeparam name="TResult">The type of the result.</typeparam>
+        /// <param name="sourceFunction">The function to memoize.</param>
+        /// <returns>The results of the function, or a cached version of it if it has run before with the same argument.</returns>
+        public static Func<T1, TResult> Memoize<T1, TResult>(this Func<T1, TResult> sourceFunction) where T1 : notnull
+        {
+            var cache = new ConcurrentDictionary<T1, TResult>();
+            return arg => cache.GetOrAdd(arg, sourceFunction);
+        }
 
-    /// <summary>
-    /// Memoize the results of a function. 
-    /// </summary>
-    /// <typeparam name="T1">The type of the first argument.</typeparam>
-    /// <typeparam name="T2">The type of the second argument.</typeparam>
-    /// <typeparam name="TResult">The type of the result.</typeparam>
-    /// <param name="sourceFunction">The function to memoize.</param>
-    /// <returns>The results of the function, or a cached version of it if it has run before with the same arguments.</returns>
-    public static Func<T1, T2, TResult> Memoize<T1, T2, TResult>(this Func<T1, T2, TResult> sourceFunction)
-    {
-        var cache = new ConcurrentDictionary<Tuple<T1, T2>, TResult>();
-        return
-            (first, second) =>
-                cache.GetOrAdd(new Tuple<T1, T2>(first, second), tuple => sourceFunction(tuple.Item1, tuple.Item2));
-    }
+        /// <summary>
+        /// Memoize the results of a function. 
+        /// </summary>
+        /// <typeparam name="T1">The type of the first argument.</typeparam>
+        /// <typeparam name="T2">The type of the second argument.</typeparam>
+        /// <typeparam name="TResult">The type of the result.</typeparam>
+        /// <param name="sourceFunction">The function to memoize.</param>
+        /// <returns>The results of the function, or a cached version of it if it has run before with the same arguments.</returns>
+        public static Func<T1, T2, TResult> Memoize<T1, T2, TResult>(this Func<T1, T2, TResult> sourceFunction)
+        {
+            var cache = new ConcurrentDictionary<Tuple<T1, T2>, TResult>();
+            return
+                (first, second) =>
+                    cache.GetOrAdd(new Tuple<T1, T2>(first, second), tuple => sourceFunction(tuple.Item1, tuple.Item2));
+        }
 
-    /// <summary>
-    /// Memoize the results of a function. 
-    /// </summary>
-    /// <typeparam name="T1">The type of the argument.</typeparam>
-    /// <typeparam name="TResult">The type of the result.</typeparam>
-    /// <typeparam name="THash">The type of the hash.</typeparam>
-    /// <param name="sourceFunction">The function to memoize.</param>
-    /// <param name="hashingFunction">A custom hash for complex type equality matching.</param>
-    /// <returns>The results of the function, or a cached version of it if it has run before with the same argument.</returns>
-    public static Func<T1, TResult> Memoize<T1, TResult, THash>(
-        this Func<T1, TResult> sourceFunction,
-        Func<T1, THash> hashingFunction) where THash : notnull
-    {
-        var cache = new ConcurrentDictionary<THash, TResult>();
-        return arg => cache.GetOrAdd(hashingFunction(arg), _ => sourceFunction(arg));
-    }
+        /// <summary>
+        /// Memoize the results of a function. 
+        /// </summary>
+        /// <typeparam name="T1">The type of the argument.</typeparam>
+        /// <typeparam name="TResult">The type of the result.</typeparam>
+        /// <typeparam name="THash">The type of the hash.</typeparam>
+        /// <param name="sourceFunction">The function to memoize.</param>
+        /// <param name="hashingFunction">A custom hash for complex type equality matching.</param>
+        /// <returns>The results of the function, or a cached version of it if it has run before with the same argument.</returns>
+        public static Func<T1, TResult> Memoize<T1, TResult, THash>(
+            this Func<T1, TResult> sourceFunction,
+            Func<T1, THash> hashingFunction) where THash : notnull
+        {
+            var cache = new ConcurrentDictionary<THash, TResult>();
+            return arg => cache.GetOrAdd(hashingFunction(arg), _ => sourceFunction(arg));
+        }
 
-    /// <summary>
-    /// Memoize the results of a function. 
-    /// </summary>
-    /// <typeparam name="T1">The type of the first argument.</typeparam>
-    /// <typeparam name="T2">The type of the second argument.</typeparam>
-    /// <typeparam name="TResult">The type of the result.</typeparam>
-    /// <typeparam name="THash">The type of the hash.</typeparam>
-    /// <param name="sourceFunction">The function to memoize.</param>
-    /// <param name="hashingFunction">A custom hash for complex type equality matching.</param>
-    /// <returns>The results of the function, or a cached version of it if it has run before with the same arguments.</returns>
-    public static Func<T1, T2, TResult> Memoize<T1, T2, TResult, THash>(
-        this Func<T1, T2, TResult> sourceFunction,
-        Func<T1, T2, THash> hashingFunction) where THash : notnull
-    {
-        var cache = new ConcurrentDictionary<THash, TResult>();
-        return (first, second) => cache.GetOrAdd(hashingFunction(first, second), _ => sourceFunction(first, second));
+        /// <summary>
+        /// Memoize the results of a function. 
+        /// </summary>
+        /// <typeparam name="T1">The type of the first argument.</typeparam>
+        /// <typeparam name="T2">The type of the second argument.</typeparam>
+        /// <typeparam name="TResult">The type of the result.</typeparam>
+        /// <typeparam name="THash">The type of the hash.</typeparam>
+        /// <param name="sourceFunction">The function to memoize.</param>
+        /// <param name="hashingFunction">A custom hash for complex type equality matching.</param>
+        /// <returns>The results of the function, or a cached version of it if it has run before with the same arguments.</returns>
+        public static Func<T1, T2, TResult> Memoize<T1, T2, TResult, THash>(
+            this Func<T1, T2, TResult> sourceFunction,
+            Func<T1, T2, THash> hashingFunction) where THash : notnull
+        {
+            var cache = new ConcurrentDictionary<THash, TResult>();
+            return (first, second) => cache.GetOrAdd(hashingFunction(first, second), _ => sourceFunction(first, second));
+        }
     }
 }

--- a/src/Audacia.Core/Extensions/MemberInfoExtensions.cs
+++ b/src/Audacia.Core/Extensions/MemberInfoExtensions.cs
@@ -3,37 +3,41 @@ using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 
-namespace Audacia.Core.Extensions;
-
-/// <summary>
-/// Extension methods for the type <see cref="MemberInfo"/>.
-/// </summary>
-public static class MemberInfoExtensions
+namespace Audacia.Core.Extensions
 {
     /// <summary>
-    /// Get <see cref="DisplayNameAttribute"/> from a property, event or public void method.
+    /// Extension methods for the type <see cref="MemberInfo"/>.
     /// </summary>
-    /// <param name="memberInfo">Member metadata.</param>
-    /// <returns>The display name.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="memberInfo"/> is null.</exception>
-    public static string? GetDataAnnotationDisplayName(this MemberInfo memberInfo)
+    public static class MemberInfoExtensions
     {
-        ArgumentNullException.ThrowIfNull(memberInfo);
-
-        var displayNameAttributes = (DisplayNameAttribute[])memberInfo.GetCustomAttributes(typeof(DisplayNameAttribute), false);
-
-        if (displayNameAttributes.Any())
+        /// <summary>
+        /// Get <see cref="DisplayNameAttribute"/> from a property, event or public void method.
+        /// </summary>
+        /// <param name="memberInfo">Member metadata.</param>
+        /// <returns>The display name.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="memberInfo"/> is null.</exception>
+        public static string? GetDataAnnotationDisplayName(this MemberInfo memberInfo)
         {
-            return displayNameAttributes[0].DisplayName;
+            if (memberInfo == null)
+            {
+                throw new ArgumentNullException(nameof(memberInfo));
+            }
+
+            var displayNameAttributes = (DisplayNameAttribute[])memberInfo.GetCustomAttributes(typeof(DisplayNameAttribute), false);
+
+            if (displayNameAttributes.Any())
+            {
+                return displayNameAttributes[0].DisplayName;
+            }
+
+            var descriptionAttributes = (DescriptionAttribute[])memberInfo.GetCustomAttributes(typeof(DescriptionAttribute), false);
+
+            if (descriptionAttributes.Any())
+            {
+                return descriptionAttributes[0].Description;
+            }
+
+            return memberInfo.Name;
         }
-
-        var descriptionAttributes = (DescriptionAttribute[])memberInfo.GetCustomAttributes(typeof(DescriptionAttribute), false);
-
-        if (descriptionAttributes.Any())
-        {
-            return descriptionAttributes[0].Description;
-        }
-
-        return memberInfo.Name;
     }
 }

--- a/src/Audacia.Core/Extensions/ObjectExtensions.cs
+++ b/src/Audacia.Core/Extensions/ObjectExtensions.cs
@@ -2,29 +2,30 @@
 using System.ComponentModel;
 using System.Linq;
 
-namespace Audacia.Core.Extensions;
-
-/// <summary>
-/// Extension methods for the type <see cref="object"/>.
-/// </summary>
-public static class ObjectExtensions
+namespace Audacia.Core.Extensions
 {
     /// <summary>
-    /// Converts an object to a dictionary with key = property name, value = value.
+    /// Extension methods for the type <see cref="object"/>.
     /// </summary>
-    /// <param name="obj">The object to convert.</param>
-    /// <returns>Dictionary with key = property name, value = value.</returns>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Member Design", "AV1130:Return type in method signature should be an interface to an unchangeable collection", Justification = "Type is limited to dictionaries.")]
-    public static IDictionary<string, object?> ToPropertyDictionary(this object obj)
+    public static class ObjectExtensions
     {
-        if (obj == null)
+        /// <summary>
+        /// Converts an object to a dictionary with key = property name, value = value.
+        /// </summary>
+        /// <param name="obj">The object to convert.</param>
+        /// <returns>Dictionary with key = property name, value = value.</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Member Design", "AV1130:Return type in method signature should be an interface to an unchangeable collection", Justification = "Type is limited to dictionaries.")]
+        public static IDictionary<string, object> ToPropertyDictionary(this object obj)
         {
-            return new Dictionary<string, object?>();
-        }
+            if (obj == null)
+            {
+                return new Dictionary<string, object>();
+            }
 
-        return
-            TypeDescriptor.GetProperties(obj.GetType())
-                .OfType<PropertyDescriptor>()
-                .ToDictionary(property => property.Name, property => property.GetValue(obj));
+            return
+                TypeDescriptor.GetProperties(obj.GetType())
+                    .OfType<PropertyDescriptor>()
+                    .ToDictionary(property => property.Name, property => property.GetValue(obj));
+        }
     }
 }

--- a/src/Audacia.Core/Extensions/QueryableExtensions.cs
+++ b/src/Audacia.Core/Extensions/QueryableExtensions.cs
@@ -2,60 +2,61 @@ using System;
 using System.Linq;
 using System.Linq.Expressions;
 
-namespace Audacia.Core.Extensions;
-
-/// <summary>
-/// Extension methods for the type <see cref="Queryable"/>.
-/// </summary>
-public static class QueryableExtensions
+namespace Audacia.Core.Extensions
 {
     /// <summary>
-    /// Append <see cref="OrderBy{T,TKey}"/> or <see cref="ThenBy{T,TKey}"/>,
-    /// depending on whether the queryable has already been ordered.
+    /// Extension methods for the type <see cref="Queryable"/>.
     /// </summary>
-    /// <typeparam name="T">The type of the collection.</typeparam>
-    /// <typeparam name="TKey">The sort properties type.</typeparam>
-    /// <param name="query">The original query.</param>
-    /// <param name="keySelector">The sort property.</param>
-    /// <param name="descending">Sort direction.</param>
-    /// <returns>The <paramref name="query"/> ordered by <typeparamref name="TKey"/>.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="query"/> is null.</exception>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Member Design", "AV1130:Return type in method signature should be an interface to an unchangeable collection", Justification = "Extends and returns IQueryable for chaining.")]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1564:Parameter in public or internal member is of type bool or bool?", Justification = "Easy to understand and implement.")]
-    public static IOrderedQueryable<T> AppendOrderBy<T, TKey>(this IQueryable<T> query, Expression<Func<T, TKey>> keySelector, bool descending) 
-        => (query?.Expression.Type ?? throw new ArgumentNullException(nameof(query), "Query can not be null")) == typeof(IOrderedQueryable<T>)
-                ? ((IOrderedQueryable<T>)query).ThenBy(keySelector, descending)
-                : query.OrderBy(keySelector, descending);
+    public static class QueryableExtensions
+    {
+        /// <summary>
+        /// Append <see cref="OrderBy{T,TKey}"/> or <see cref="ThenBy{T,TKey}"/>,
+        /// depending on whether the queryable has already been ordered.
+        /// </summary>
+        /// <typeparam name="T">The type of the collection.</typeparam>
+        /// <typeparam name="TKey">The sort properties type.</typeparam>
+        /// <param name="query">The original query.</param>
+        /// <param name="keySelector">The sort property.</param>
+        /// <param name="descending">Sort direction.</param>
+        /// <returns>The <paramref name="query"/> ordered by <typeparamref name="TKey"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="query"/> is null.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Member Design", "AV1130:Return type in method signature should be an interface to an unchangeable collection", Justification = "Extends and returns IQueryable for chaining.")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1564:Parameter in public or internal member is of type bool or bool?", Justification = "Easy to understand and implement.")]
+        public static IOrderedQueryable<T> AppendOrderBy<T, TKey>(this IQueryable<T> query, Expression<Func<T, TKey>> keySelector, bool descending)
+            => (query?.Expression.Type ?? throw new ArgumentNullException(nameof(query), "Query can not be null")) == typeof(IOrderedQueryable<T>)
+                    ? ((IOrderedQueryable<T>)query).ThenBy(keySelector, descending)
+                    : query.OrderBy(keySelector, descending);
 
-    /// <summary>
-    /// Sort either ascending or descending, depending on the provided <paramref name="descending"/>.
-    /// </summary>
-    /// <typeparam name="T">The type of the collection.</typeparam>
-    /// <typeparam name="TKey">The sort properties type.</typeparam>
-    /// <param name="query">The original query.</param>
-    /// <param name="keySelector">The sort property.</param>
-    /// <param name="descending">Sort direction.</param>
-    /// <returns>The <paramref name="query"/> ordered by <typeparamref name="TKey"/>.</returns>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Member Design", "AV1130:Return type in method signature should be an interface to an unchangeable collection", Justification = "Returns IOrderedQueryable for chaining.")]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1564:Parameter in public or internal member is of type bool or bool?", Justification = "Easy to understand and implement.")]
-    public static IOrderedQueryable<T> OrderBy<T, TKey>(this IQueryable<T> query, Expression<Func<T, TKey>> keySelector, bool descending)
-        => descending
-            ? query.OrderByDescending(keySelector)
-            : query.OrderBy(keySelector);
+        /// <summary>
+        /// Sort either ascending or descending, depending on the provided <paramref name="descending"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of the collection.</typeparam>
+        /// <typeparam name="TKey">The sort properties type.</typeparam>
+        /// <param name="query">The original query.</param>
+        /// <param name="keySelector">The sort property.</param>
+        /// <param name="descending">Sort direction.</param>
+        /// <returns>The <paramref name="query"/> ordered by <typeparamref name="TKey"/>.</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Member Design", "AV1130:Return type in method signature should be an interface to an unchangeable collection", Justification = "Returns IOrderedQueryable for chaining.")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1564:Parameter in public or internal member is of type bool or bool?", Justification = "Easy to understand and implement.")]
+        public static IOrderedQueryable<T> OrderBy<T, TKey>(this IQueryable<T> query, Expression<Func<T, TKey>> keySelector, bool descending)
+            => descending
+                ? query.OrderByDescending(keySelector)
+                : query.OrderBy(keySelector);
 
-    /// <summary>
-    /// Sort either ascending or descending, depending on the provided <paramref name="descending"/>.
-    /// </summary>
-    /// <typeparam name="T">The type of the collection.</typeparam>
-    /// <typeparam name="TKey">The sort properties type.</typeparam>
-    /// <param name="query">The original query.</param>
-    /// <param name="keySelector">The sort property.</param>
-    /// <param name="descending">Sort direction.</param>
-    /// <returns>The <paramref name="query"/> ordered by <typeparamref name="TKey"/>.</returns>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Member Design", "AV1130:Return type in method signature should be an interface to an unchangeable collection", Justification = "Returns IOrderedQueryable for chaining.")]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1564:Parameter in public or internal member is of type bool or bool?", Justification = "Easy to understand and implement.")]
-    public static IOrderedQueryable<T> ThenBy<T, TKey>(this IOrderedQueryable<T> query, Expression<Func<T, TKey>> keySelector, bool descending)
-        => descending
-            ? query.ThenByDescending(keySelector)
-            : query.ThenBy(keySelector);
+        /// <summary>
+        /// Sort either ascending or descending, depending on the provided <paramref name="descending"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of the collection.</typeparam>
+        /// <typeparam name="TKey">The sort properties type.</typeparam>
+        /// <param name="query">The original query.</param>
+        /// <param name="keySelector">The sort property.</param>
+        /// <param name="descending">Sort direction.</param>
+        /// <returns>The <paramref name="query"/> ordered by <typeparamref name="TKey"/>.</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Member Design", "AV1130:Return type in method signature should be an interface to an unchangeable collection", Justification = "Returns IOrderedQueryable for chaining.")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1564:Parameter in public or internal member is of type bool or bool?", Justification = "Easy to understand and implement.")]
+        public static IOrderedQueryable<T> ThenBy<T, TKey>(this IOrderedQueryable<T> query, Expression<Func<T, TKey>> keySelector, bool descending)
+            => descending
+                ? query.ThenByDescending(keySelector)
+                : query.ThenBy(keySelector);
+    }
 }

--- a/src/Audacia.Core/Extensions/StreamExtensions.cs
+++ b/src/Audacia.Core/Extensions/StreamExtensions.cs
@@ -1,45 +1,49 @@
 ﻿using System;
 using System.IO;
 
-namespace Audacia.Core.Extensions;
-
-/// <summary>
-/// Extension methods for the type <see cref="Stream"/>.
-/// </summary>
-public static class StreamExtensions
+namespace Audacia.Core.Extensions
 {
     /// <summary>
-    /// Copies a stream in to a new memory stream.
+    /// Extension methods for the type <see cref="Stream"/>.
     /// </summary>
-    /// <param name="source">The source stream.</param>
-    /// <param name="close">Whether to close the original stream.</param>
-    /// <returns>The copied stream.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1564:Parameter in public or internal member is of type bool or bool?", Justification = "Easy to understand and implement.")]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "ACL1002:Member or local function contains too many statements", Justification = "Easier to read and understand.")]
-    public static MemoryStream ToMemoryStream(this Stream source, bool close = false)
+    public static class StreamExtensions
     {
-        ArgumentNullException.ThrowIfNull(source);
-
-        const int readSize = 256;
-        var buffer = new byte[readSize];
-        var memoryStream = new MemoryStream();
-
-        var count = source.Read(buffer, 0, readSize);
-
-        while (count > 0)
+        /// <summary>
+        /// Copies a stream in to a new memory stream.
+        /// </summary>
+        /// <param name="source">The source stream.</param>
+        /// <param name="close">Whether to close the original stream.</param>
+        /// <returns>The copied stream.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1564:Parameter in public or internal member is of type bool or bool?", Justification = "Easy to understand and implement.")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "ACL1002:Member or local function contains too many statements", Justification = "Easier to read and understand.")]
+        public static MemoryStream ToMemoryStream(this Stream source, bool close = false)
         {
-            memoryStream.Write(buffer, 0, count);
-            count = source.Read(buffer, 0, readSize);
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            const int readSize = 256;
+            var buffer = new byte[readSize];
+            var memoryStream = new MemoryStream();
+
+            var count = source.Read(buffer, 0, readSize);
+
+            while (count > 0)
+            {
+                memoryStream.Write(buffer, 0, count);
+                count = source.Read(buffer, 0, readSize);
+            }
+
+            memoryStream.Position = 0;
+
+            if (close)
+            {
+                source.Close();
+            }
+
+            return memoryStream;
         }
-
-        memoryStream.Position = 0;
-
-        if (close)
-        {
-            source.Close();
-        }
-
-        return memoryStream;
     }
 }

--- a/src/Audacia.Core/Extensions/StringExtensions.cs
+++ b/src/Audacia.Core/Extensions/StringExtensions.cs
@@ -8,263 +8,268 @@ using System.Linq.Expressions;
 using System.Text;
 using System.Text.RegularExpressions;
 
-namespace Audacia.Core.Extensions;
-
-/// <summary>
-/// Extension methods for the type <see cref="string"/>.
-/// </summary>
-public static class StringExtensions
+namespace Audacia.Core.Extensions
 {
     /// <summary>
-    /// Removes invalid file name characters from a string to returns a string than can be used as part of a filename or directory structure.
+    /// Extension methods for the type <see cref="string"/>.
     /// </summary>
-    /// <param name="input">The input string.</param>
-    /// <returns>The output string with unsafe characters removed.</returns>
-    public static string ToSafeFilename(this string input)
+    public static class StringExtensions
     {
-        var invalidCharacters = Path.GetInvalidFileNameChars();
-
-        return string.IsNullOrWhiteSpace(input)
-            ? input
-            : new string(input.Trim().Where(c => !invalidCharacters.Contains(c)).ToArray());
-    }
-
-    /// <summary>
-    /// Attempts to convert any string to the requested type.
-    /// </summary>
-    /// <typeparam name="T">The type to convert to.</typeparam>
-    /// <param name="input">The string to convert.</param>
-    /// <param name="output">The converted result (or default if convert fails).</param>
-    /// <param name="invariant">Whether to use culture invariance in the conversion.</param>
-    /// <returns>Whether the conversion passed or failed.</returns>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1564:Parameter in public or internal member is of type bool or bool?", Justification = "Easy to understand and implement.")]
-    public static bool TryConvertToType<T>(this string input, out T output, bool invariant = false)
-    {
-        try
+        /// <summary>
+        /// Removes invalid file name characters from a string to returns a string than can be used as part of a filename or directory structure.
+        /// </summary>
+        /// <param name="input">The input string.</param>
+        /// <returns>The output string with unsafe characters removed.</returns>
+        public static string ToSafeFilename(this string input)
         {
-            output = input.ConvertToType<T>(invariant);
-            return true;
+            var invalidCharacters = Path.GetInvalidFileNameChars();
+
+            return string.IsNullOrWhiteSpace(input)
+                ? input
+                : new string(input.Trim().Where(c => !invalidCharacters.Contains(c)).ToArray());
         }
-        catch (NotSupportedException)
+
+        /// <summary>
+        /// Attempts to convert any string to the requested type.
+        /// </summary>
+        /// <typeparam name="T">The type to convert to.</typeparam>
+        /// <param name="input">The string to convert.</param>
+        /// <param name="output">The converted result (or default if convert fails).</param>
+        /// <param name="invariant">Whether to use culture invariance in the conversion.</param>
+        /// <returns>Whether the conversion passed or failed.</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1564:Parameter in public or internal member is of type bool or bool?", Justification = "Easy to understand and implement.")]
+        public static bool TryConvertToType<T>(this string input, out T output, bool invariant = false)
         {
-            output = default!;
-            return false;
+            try
+            {
+                output = input.ConvertToType<T>(invariant);
+                return true;
+            }
+            catch (NotSupportedException)
+            {
+                output = default!;
+                return false;
+            }
         }
-    }
 
-    /// <summary>
-    /// Adds spaces before capitals in a string.
-    /// </summary>
-    /// <param name="source">The source string.</param>
-    /// <returns>The transformed string.</returns>
-    public static string AddSpacesBeforeCapitals(this string source)
-    {
-        return Regex.Replace(source, @"(\B[A-Z]+?(?=[A-Z][^A-Z])|\B[A-Z]+?(?=[^A-Z]))", " $1");
-    }
-
-    /// <summary>
-    /// Converts any string to the requested type.
-    /// </summary>
-    /// <typeparam name="T">The type to convert to.</typeparam>
-    /// <param name="input">The string to convert.</param>
-    /// <param name="invariant">Whether to use culture invariance in the conversion.</param>
-    /// <returns>The converted string.</returns>
-    /// <exception cref="NotSupportedException">If cannot convert from input.</exception>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1564:Parameter in public or internal member is of type bool or bool?", Justification = "Easy to understand and implement.")]
-    public static T ConvertToType<T>(this string input, bool invariant = false)
-    {
-        var typeConverter = TypeDescriptor.GetConverter(typeof(T));
-
-        ArgumentNullException.ThrowIfNull(input);
-
-        var result = (invariant ? typeConverter.ConvertFromInvariantString(input) : typeConverter.ConvertFromString(input));
-
-        return (T)(result ?? throw new NotSupportedException("Input cannot be converted."));
-    }
-
-    /// <summary>
-    /// Replace any instances of the dictionary keys with the dictionary values in the requested string.
-    /// </summary>
-    /// <param name="source">The source string.</param>
-    /// <param name="findReplace">The find and replace pairs.</param>
-    /// <returns>The resultant string.</returns>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Member Design", "AV1115:Member or local function contains the word 'and', which suggests doing multiple things", Justification = "Makes sense that it does two things, for ease of use.")]
-    public static string FindAndReplace(this string source, IDictionary<string, string> findReplace)
-    {
-        if (string.IsNullOrEmpty(source) || findReplace == null)
+        /// <summary>
+        /// Adds spaces before capitals in a string.
+        /// </summary>
+        /// <param name="source">The source string.</param>
+        /// <returns>The transformed string.</returns>
+        public static string AddSpacesBeforeCapitals(this string source)
         {
+            return Regex.Replace(source, @"(\B[A-Z]+?(?=[A-Z][^A-Z])|\B[A-Z]+?(?=[^A-Z]))", " $1");
+        }
+
+        /// <summary>
+        /// Converts any string to the requested type.
+        /// </summary>
+        /// <typeparam name="T">The type to convert to.</typeparam>
+        /// <param name="input">The string to convert.</param>
+        /// <param name="invariant">Whether to use culture invariance in the conversion.</param>
+        /// <returns>The converted string.</returns>
+        /// <exception cref="NotSupportedException">If cannot convert from input.</exception>
+        /// <exception cref="ArgumentNullException">enumType or value is null.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1564:Parameter in public or internal member is of type bool or bool?", Justification = "Easy to understand and implement.")]
+        public static T ConvertToType<T>(this string input, bool invariant = false)
+        {
+            if (input == null)
+            {
+                throw new ArgumentNullException(nameof(input));
+            }
+
+            var typeConverter = TypeDescriptor.GetConverter(typeof(T));
+
+            var result = (invariant ? typeConverter.ConvertFromInvariantString(input) : typeConverter.ConvertFromString(input));
+
+            return (T)(result ?? throw new NotSupportedException("Input cannot be converted."));
+        }
+
+        /// <summary>
+        /// Replace any instances of the dictionary keys with the dictionary values in the requested string.
+        /// </summary>
+        /// <param name="source">The source string.</param>
+        /// <param name="findReplace">The find and replace pairs.</param>
+        /// <returns>The resultant string.</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Member Design", "AV1115:Member or local function contains the word 'and', which suggests doing multiple things", Justification = "Makes sense that it does two things, for ease of use.")]
+        public static string FindAndReplace(this string source, IDictionary<string, string> findReplace)
+        {
+            if (string.IsNullOrEmpty(source) || findReplace == null)
+            {
+                return source;
+            }
+
+            var stringBuilder = new StringBuilder(source);
+
+            foreach (var item in findReplace)
+            {
+                stringBuilder.Replace(item.Key, item.Value);
+            }
+
+            return stringBuilder.ToString();
+        }
+
+        /// <summary>
+        /// Takes a substring from the end of a string.
+        /// </summary>
+        /// <param name="input">The source string.</param>
+        /// <param name="tailLength">The length of the substring.</param>
+        /// <returns>The substring.</returns>
+        public static string SubstringFromEnd(this string input, int tailLength)
+        {
+            return (string.IsNullOrEmpty(input) || tailLength >= input.Length)
+                ? input
+                : input.Substring(input.Length - tailLength);
+        }
+
+        /// <summary>
+        /// Converts a string to title case.
+        /// </summary>
+        /// <param name="source">The source string.</param>
+        /// <returns>The converted string.</returns>
+        public static string ToTitleCase(this string source)
+        {
+            return CultureInfo.CurrentCulture.TextInfo.ToTitleCase(source);
+        }
+
+        /// <summary>
+        /// Removes non numeric values from a string.
+        /// </summary>
+        /// <param name="source">The source string.</param>
+        /// <returns>The string stripped of everything except numerals, full stops and negative figures.</returns>
+        public static string RemoveNonNumeric(this string source)
+        {
+            return string.IsNullOrWhiteSpace(source)
+                ? string.Empty
+                : new string(source.ToCharArray().Where(e => char.IsDigit(e) || e == '.' || e == '-').ToArray());
+        }
+
+        /// <summary>
+        /// Removes numeric values from a string.
+        /// </summary>
+        /// <param name="source">The source string.</param>
+        /// <returns>The string stripped of numerals.</returns>
+        public static string RemoveNumeric(this string source)
+        {
+            return string.IsNullOrWhiteSpace(source)
+                ? string.Empty
+                : new string(source.ToCharArray().Where(e => !char.IsDigit(e)).ToArray());
+        }
+
+        /// <summary>
+        /// Determines whether the contents of a string are numeric.
+        /// </summary>
+        /// <param name="input">The source string.</param>
+        /// <returns>The result.</returns>
+        public static bool IsNumeric(this string input)
+        {
+            return !string.IsNullOrWhiteSpace(input) &&
+                   input.ToCharArray().All(e => char.IsDigit(e) || e == '.' || e == '-');
+        }
+
+        /// <summary>
+        /// Determines whether a string contains numerals.
+        /// </summary>
+        /// <param name="input">The source string.</param>
+        /// <returns>The result.</returns>
+        public static bool HasNumeric(this string input)
+        {
+            return !string.IsNullOrWhiteSpace(input) && input.ToCharArray().Any(char.IsDigit);
+        }
+
+        /// <summary>
+        /// Trims all instances of the requested string from the start of a string.
+        /// </summary>
+        /// <param name="source">The source string.</param>
+        /// <param name="trimmable">The string to strip from the start.</param>
+        /// <returns>The stripped string.</returns>
+        public static string TrimStart(this string source, string trimmable)
+        {
+            if (string.IsNullOrEmpty(source) || string.IsNullOrEmpty(trimmable))
+            {
+                return source;
+            }
+
+            while (source.StartsWith(trimmable))
+            {
+                source = source.Substring(trimmable.Length);
+            }
+
             return source;
         }
 
-        var stringBuilder = new StringBuilder(source);
-
-        foreach (var item in findReplace)
+        /// <summary>
+        /// Truncates a string by a specified number of characters, and includes an appended string if it exceeds a specified limits.
+        /// NOTE: The amount of characters taken if the string exceeds the character limit is: (CharacterLimit - appendString.length).
+        /// </summary>
+        /// <param name="source">The source string.</param>
+        /// <param name="characterLimit">The amount of characters to accept before truncating.</param>
+        /// <param name="appendStringIfLimitExceeded">Some characters to append if limit hit.</param>
+        /// <returns>Returns <paramref name="source"/> limited to <paramref name="characterLimit"/>.</returns>
+        public static string Truncate(this string source, int characterLimit, string appendStringIfLimitExceeded = "...")
         {
-            stringBuilder.Replace(item.Key, item.Value);
+            if (string.IsNullOrEmpty(source) || source.Length <= characterLimit)
+            {
+                return source;
+            }
+
+            return source.Substring(0, characterLimit - (appendStringIfLimitExceeded ?? string.Empty).Length).Trim() + appendStringIfLimitExceeded;
         }
 
-        return stringBuilder.ToString();
-    }
-
-    /// <summary>
-    /// Takes a substring from the end of a string.
-    /// </summary>
-    /// <param name="input">The source string.</param>
-    /// <param name="tailLength">The length of the substring.</param>
-    /// <returns>The substring.</returns>
-    public static string SubstringFromEnd(this string input, int tailLength)
-    {
-        return (string.IsNullOrEmpty(input) || tailLength >= input.Length)
-            ? input
-            : input.Substring(input.Length - tailLength);
-    }
-
-    /// <summary>
-    /// Converts a string to title case.
-    /// </summary>
-    /// <param name="source">The source string.</param>
-    /// <returns>The converted string.</returns>
-    public static string ToTitleCase(this string source)
-    {
-        return CultureInfo.CurrentCulture.TextInfo.ToTitleCase(source);
-    }
-
-    /// <summary>
-    /// Removes non numeric values from a string.
-    /// </summary>
-    /// <param name="source">The source string.</param>
-    /// <returns>The string stripped of everything except numerals, full stops and negative figures.</returns>
-    public static string RemoveNonNumeric(this string source)
-    {
-        return string.IsNullOrWhiteSpace(source)
-            ? string.Empty
-            : new string(source.ToCharArray().Where(e => char.IsDigit(e) || e == '.' || e == '-').ToArray());
-    }
-
-    /// <summary>
-    /// Removes numeric values from a string.
-    /// </summary>
-    /// <param name="source">The source string.</param>
-    /// <returns>The string stripped of numerals.</returns>
-    public static string RemoveNumeric(this string source)
-    {
-        return string.IsNullOrWhiteSpace(source)
-            ? string.Empty
-            : new string(source.ToCharArray().Where(e => !char.IsDigit(e)).ToArray());
-    }
-
-    /// <summary>
-    /// Determines whether the contents of a string are numeric.
-    /// </summary>
-    /// <param name="input">The source string.</param>
-    /// <returns>The result.</returns>
-    public static bool IsNumeric(this string input)
-    {
-        return !string.IsNullOrWhiteSpace(input) &&
-               input.ToCharArray().All(e => char.IsDigit(e) || e == '.' || e == '-');
-    }
-
-    /// <summary>
-    /// Determines whether a string contains numerals.
-    /// </summary>
-    /// <param name="input">The source string.</param>
-    /// <returns>The result.</returns>
-    public static bool HasNumeric(this string input)
-    {
-        return !string.IsNullOrWhiteSpace(input) && input.ToCharArray().Any(char.IsDigit);
-    }
-
-    /// <summary>
-    /// Trims all instances of the requested string from the start of a string.
-    /// </summary>
-    /// <param name="source">The source string.</param>
-    /// <param name="trimmable">The string to strip from the start.</param>
-    /// <returns>The stripped string.</returns>
-    public static string TrimStart(this string source, string trimmable)
-    {
-        if (string.IsNullOrEmpty(source) || string.IsNullOrEmpty(trimmable))
+        /// <summary>
+        /// Split a camel case string into separate words.
+        /// </summary>
+        /// <param name="source">A string in a different case than Camel Case.</param>
+        /// <returns>The split string.</returns>
+        public static string SplitCamelCase(this string source)
         {
-            return source;
+            return Regex.Replace(source, "([A-Z])", " $1", RegexOptions.Compiled).Trim();
         }
 
-        while (source.StartsWith(trimmable))
+        /// <summary>
+        /// Lowercase the first character of a string.
+        /// </summary>
+        /// <param name="input">The source string.</param>
+        /// <returns>The transformed string.</returns>
+        public static string LowerCaseFirst(this string input)
         {
-            source = source.Substring(trimmable.Length);
+            return string.IsNullOrWhiteSpace(input) ? input : char.ToLowerInvariant(input[0]) + input.Substring(1);
         }
 
-        return source;
-    }
-
-    /// <summary>
-    /// Truncates a string by a specified number of characters, and includes an appended string if it exceeds a specified limits.
-    /// NOTE: The amount of characters taken if the string exceeds the character limit is: (CharacterLimit - appendString.length).
-    /// </summary>
-    /// <param name="source">The source string.</param>
-    /// <param name="characterLimit">The amount of characters to accept before truncating.</param>
-    /// <param name="appendStringIfLimitExceeded">Some characters to append if limit hit.</param>
-    /// <returns>Returns <paramref name="source"/> limited to <paramref name="characterLimit"/>.</returns>
-    public static string Truncate(this string source, int characterLimit, string appendStringIfLimitExceeded = "...")
-    {
-        if (string.IsNullOrEmpty(source) || source.Length <= characterLimit)
+        /// <summary>
+        /// Uppercase the first character of a string.
+        /// </summary>
+        /// <param name="input">The source string.</param>
+        /// <returns>The transformed string.</returns>
+        public static string UpperCaseFirst(this string input)
         {
-            return source;
+            return string.IsNullOrWhiteSpace(input) ? input : char.ToUpperInvariant(input[0]) + input.Substring(1);
         }
 
-        return source.Substring(0, characterLimit - (appendStringIfLimitExceeded ?? string.Empty).Length).Trim() + appendStringIfLimitExceeded;
-    }
-
-    /// <summary>
-    /// Split a camel case string into separate words.
-    /// </summary>
-    /// <param name="source">A string in a different case than Camel Case.</param>
-    /// <returns>The split string.</returns>
-    public static string SplitCamelCase(this string source)
-    {
-        return Regex.Replace(source, "([A-Z])", " $1", RegexOptions.Compiled).Trim();
-    }
-
-    /// <summary>
-    /// Lowercase the first character of a string.
-    /// </summary>
-    /// <param name="input">The source string.</param>
-    /// <returns>The transformed string.</returns>
-    public static string LowerCaseFirst(this string input)
-    {
-        return string.IsNullOrWhiteSpace(input) ? input : char.ToLowerInvariant(input[0]) + input.Substring(1);
-    }
-
-    /// <summary>
-    /// Uppercase the first character of a string.
-    /// </summary>
-    /// <param name="input">The source string.</param>
-    /// <returns>The transformed string.</returns>
-    public static string UpperCaseFirst(this string input)
-    {
-        return string.IsNullOrWhiteSpace(input) ? input : char.ToUpperInvariant(input[0]) + input.Substring(1);
-    }
-
-    /// <summary>
-    /// Given the name of a property return an expression representing `t => t.{propertyName}`.
-    /// </summary>
-    /// <typeparam name="T">The type that the property must live on.</typeparam>
-    /// <param name="propertyName">The name of the property to return.</param>
-    /// <returns>An expression for the property <paramref name="propertyName"/>.</returns>
-    /// <exception cref="ArgumentException">If the property doesn't exist on T.</exception>
-    public static Expression<Func<T, object>> ToExpression<T>(this string propertyName)
-    {
-        //Upper case first to account from lower case JSON
-        var type = typeof(T);
-        var propertyInfo = type.GetProperty(propertyName.UpperCaseFirst());
-
-        if (propertyInfo == null)
+        /// <summary>
+        /// Given the name of a property return an expression representing `t => t.{propertyName}`.
+        /// </summary>
+        /// <typeparam name="T">The type that the property must live on.</typeparam>
+        /// <param name="propertyName">The name of the property to return.</param>
+        /// <returns>An expression for the property <paramref name="propertyName"/>.</returns>
+        /// <exception cref="ArgumentException">If the property doesn't exist on T.</exception>
+        public static Expression<Func<T, object>> ToExpression<T>(this string propertyName)
         {
-            // Someone has provided a property that doesn't exist on the object
-            throw new ArgumentException($"Provided property name isn't a member of {typeof(T).Name}", nameof(propertyName));
+            //Upper case first to account from lower case JSON
+            var type = typeof(T);
+            var propertyInfo = type.GetProperty(propertyName.UpperCaseFirst());
+
+            if (propertyInfo == null)
+            {
+                // Someone has provided a property that doesn't exist on the object
+                throw new ArgumentException($"Provided property name isn't a member of {typeof(T).Name}", nameof(propertyName));
+            }
+
+            var parameterExpression = Expression.Parameter(type);
+            var propertyExpression = Expression.PropertyOrField(parameterExpression, propertyInfo.Name);
+
+            return Expression.Lambda<Func<T, object>>(propertyExpression, parameterExpression);
         }
-
-        var parameterExpression = Expression.Parameter(type);
-        var propertyExpression = Expression.PropertyOrField(parameterExpression, propertyInfo.Name);
-
-        return Expression.Lambda<Func<T, object>>(propertyExpression, parameterExpression);
     }
 }

--- a/src/Audacia.Core/Extensions/TypeExtensions.cs
+++ b/src/Audacia.Core/Extensions/TypeExtensions.cs
@@ -1,17 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace Audacia.Core.Extensions;
-
-/// <summary>
-/// Extension methods for the type <see cref="Type"/>.
-/// </summary>
-public static class TypeExtensions
+namespace Audacia.Core.Extensions
 {
     /// <summary>
-    /// Type codes to check against in method <see cref="IsNumeric"/>.
+    /// Extension methods for the type <see cref="Type"/>.
     /// </summary>
-    private static readonly List<TypeCode> NumberTypeCodes = new List<TypeCode>
+    public static class TypeExtensions
+    {
+        /// <summary>
+        /// Type codes to check against in method <see cref="IsNumeric"/>.
+        /// </summary>
+        private static readonly List<TypeCode> NumberTypeCodes = new List<TypeCode>
     {
         TypeCode.Byte,
         TypeCode.SByte,
@@ -26,46 +26,53 @@ public static class TypeExtensions
         TypeCode.Single
     };
 
-    /// <summary>
-    /// Determine of specified type is nullable.
-    /// </summary>
-    /// <param name="this">The type to check if it is nullable.</param>
-    /// <exception cref="ArgumentNullException"><paramref name="this"/> is null.</exception>
-    /// <returns>If the type is nullable.</returns>
-    public static bool IsNullable(this Type @this)
-    {
-        ArgumentNullException.ThrowIfNull(@this);
-
-        return !@this.IsValueType || (@this.IsGenericType && @this.GetGenericTypeDefinition() == typeof(Nullable<>));
-    }
-
-    /// <summary>
-    /// Return underlying type if type is nullable otherwise return the type.
-    /// </summary>
-    /// <param name="this">The type to check if it is nullable.</param>
-    /// <returns>The none-nullable type.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="this"/> is null.</exception>
-    public static Type GetUnderlyingTypeIfNullable(this Type @this)
-    {
-        ArgumentNullException.ThrowIfNull(@this);
-
-        if (@this.IsNullable())
+        /// <summary>
+        /// Determine of specified type is nullable.
+        /// </summary>
+        /// <param name="this">The type to check if it is nullable.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="this"/> is null.</exception>
+        /// <returns>If the type is nullable.</returns>
+        public static bool IsNullable(this Type @this)
         {
-            return !@this.IsValueType ? @this : Nullable.GetUnderlyingType(@this)!;
+            if (@this == null)
+            {
+                throw new ArgumentNullException(nameof(@this));
+            }
+
+            return !@this.IsValueType || (@this.IsGenericType && @this.GetGenericTypeDefinition() == typeof(Nullable<>));
         }
 
-        return @this;
-    }
+        /// <summary>
+        /// Return underlying type if type is nullable otherwise return the type.
+        /// </summary>
+        /// <param name="this">The type to check if it is nullable.</param>
+        /// <returns>The none-nullable type.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="this"/> is null.</exception>
+        public static Type GetUnderlyingTypeIfNullable(this Type @this)
+        {
+            if (@this == null)
+            {
+                throw new ArgumentNullException(nameof(@this));
+            }
 
-    /// <summary>
-    /// Determines whether the underlying type is numeric.
-    /// </summary>
-    /// <param name="this">Property Type.</param> 
-    /// <returns>true if the <see cref="TypeCode"/> is numeric.</returns>
-    public static bool IsNumeric(this Type @this)
-    {
-        var underlyingType = @this.GetUnderlyingTypeIfNullable();
-        var underlyingTypeCode = Type.GetTypeCode(underlyingType);
-        return NumberTypeCodes.Contains(underlyingTypeCode);
+            if (@this.IsNullable())
+            {
+                return !@this.IsValueType ? @this : Nullable.GetUnderlyingType(@this)!;
+            }
+
+            return @this;
+        }
+
+        /// <summary>
+        /// Determines whether the underlying type is numeric.
+        /// </summary>
+        /// <param name="this">Property Type.</param> 
+        /// <returns>true if the <see cref="TypeCode"/> is numeric.</returns>
+        public static bool IsNumeric(this Type @this)
+        {
+            var underlyingType = @this.GetUnderlyingTypeIfNullable();
+            var underlyingTypeCode = Type.GetTypeCode(underlyingType);
+            return NumberTypeCodes.Contains(underlyingTypeCode);
+        }
     }
 }

--- a/src/Audacia.Core/Extensions/UriExtensions.cs
+++ b/src/Audacia.Core/Extensions/UriExtensions.cs
@@ -1,38 +1,39 @@
 ﻿using System;
 using System.Linq;
 
-namespace Audacia.Core.Extensions;
-
-/// <summary>
-/// Extension methods for the type <see cref="Uri"/>.
-/// </summary>
-public static class UriExtensions
+namespace Audacia.Core.Extensions
 {
     /// <summary>
-    /// Append additional sub-paths to a URI.
+    /// Extension methods for the type <see cref="Uri"/>.
     /// </summary>
-    /// <param name="uri">The uri URI.</param>
-    /// <param name="paths">Paths to append.</param>
-    /// <returns>The appended URI.</returns>
-    public static Uri Append(this Uri uri, params string[] paths)
+    public static class UriExtensions
     {
-        uri = new Uri(paths.Aggregate(
-            uri?.AbsoluteUri ?? string.Empty,
-            (current, path) => $"{current.TrimEnd('/')}/{path.TrimStart('/')}"));
+        /// <summary>
+        /// Append additional sub-paths to a URI.
+        /// </summary>
+        /// <param name="uri">The uri URI.</param>
+        /// <param name="paths">Paths to append.</param>
+        /// <returns>The appended URI.</returns>
+        public static Uri Append(this Uri uri, params string[] paths)
+        {
+            uri = new Uri(paths.Aggregate(
+                uri?.AbsoluteUri ?? string.Empty,
+                (current, path) => $"{current.TrimEnd('/')}/{path.TrimStart('/')}"));
 
-        return uri;
-    }
+            return uri;
+        }
 
-    /// <summary>
-    /// Gets the domain from a uri.
-    /// </summary>
-    /// <param name="input">The uri URI.</param>
-    /// <returns>The domain.</returns>
-    public static string GetDomain(this Uri input)
-    {
-        return input == null
-            ? string.Empty
-            : input.Scheme + Uri.SchemeDelimiter + input.Host +
-               (input.IsDefaultPort ? string.Empty : ":" + input.Port);
+        /// <summary>
+        /// Gets the domain from a uri.
+        /// </summary>
+        /// <param name="input">The uri URI.</param>
+        /// <returns>The domain.</returns>
+        public static string GetDomain(this Uri input)
+        {
+            return input == null
+                ? string.Empty
+                : input.Scheme + Uri.SchemeDelimiter + input.Host +
+                   (input.IsDefaultPort ? string.Empty : ":" + input.Port);
+        }
     }
 }

--- a/src/Audacia.Core/ICurrentUserProvider.cs
+++ b/src/Audacia.Core/ICurrentUserProvider.cs
@@ -1,14 +1,15 @@
-﻿namespace Audacia.Core;
-
-/// <summary>
-/// Represents a type that can access the currently authenticated user.
-/// </summary>
-/// <typeparam name="TId">The type of the user Id.</typeparam>
-public interface ICurrentUserProvider<TId>
+﻿namespace Audacia.Core
 {
     /// <summary>
-    /// Gets the Id of the current user.
+    /// Represents a type that can access the currently authenticated user.
     /// </summary>
-    /// <returns>The current user's Id.</returns>
-    TId GetCurrentUserId();
+    /// <typeparam name="TId">The type of the user Id.</typeparam>
+    public interface ICurrentUserProvider<TId>
+    {
+        /// <summary>
+        /// Gets the Id of the current user.
+        /// </summary>
+        /// <returns>The current user's Id.</returns>
+        TId GetCurrentUserId();
+    }
 }

--- a/src/Audacia.Core/IDateTimeOffsetProvider.cs
+++ b/src/Audacia.Core/IDateTimeOffsetProvider.cs
@@ -1,29 +1,30 @@
 ﻿using System;
 
-namespace Audacia.Core;
-
-/// <summary>
-/// An interface to provide a DateTime properties to other functionality, to allow for better mocking and testing.
-/// </summary>
-public interface IDateTimeOffsetProvider
+namespace Audacia.Core
 {
     /// <summary>
-    /// Gets mockable DateTimeOffset.UtcNow replacement.
+    /// An interface to provide a DateTime properties to other functionality, to allow for better mocking and testing.
     /// </summary>
-    DateTimeOffset UtcNow { get; }
+    public interface IDateTimeOffsetProvider
+    {
+        /// <summary>
+        /// Gets mockable DateTimeOffset.UtcNow replacement.
+        /// </summary>
+        DateTimeOffset UtcNow { get; }
 
-    /// <summary>
-    /// Gets mockable DateTimeOffset.Now replacement.
-    /// </summary>
-    DateTimeOffset Now { get; }
+        /// <summary>
+        /// Gets mockable DateTimeOffset.Now replacement.
+        /// </summary>
+        DateTimeOffset Now { get; }
 
-    /// <summary>
-    /// Gets mockable DateTime.Today replacement.
-    /// </summary>
-    DateTimeOffset Today { get; }
+        /// <summary>
+        /// Gets mockable DateTime.Today replacement.
+        /// </summary>
+        DateTimeOffset Today { get; }
 
-    /// <summary>
-    /// Gets mockable DateTime.Today replacement, but being the date from UtcNow.
-    /// </summary>
-    DateTimeOffset UtcToday { get; }
+        /// <summary>
+        /// Gets mockable DateTime.Today replacement, but being the date from UtcNow.
+        /// </summary>
+        DateTimeOffset UtcToday { get; }
+    }
 }

--- a/src/Audacia.Core/IResult.cs
+++ b/src/Audacia.Core/IResult.cs
@@ -1,31 +1,32 @@
 ﻿using System.Collections.Generic;
 
-namespace Audacia.Core;
-
-/// <summary>
-/// Indicates the success or failure of a an operation with data or a collection for errors.
-/// </summary>
-/// <typeparam name="TOutput">The type of data.</typeparam>
-public interface IResult<out TOutput> : IResult
+namespace Audacia.Core
 {
     /// <summary>
-    /// Gets the data result of a operation.
+    /// Indicates the success or failure of a an operation with data or a collection for errors.
     /// </summary>
-    TOutput Output { get; }
-}
-
-/// <summary>
-/// Indicates the success or failure of a an operation with a collection for errors (if applicable).
-/// </summary>
-public interface IResult
-{
-    /// <summary>
-    /// Gets a value indicating whether gets a flag indicating whether the operation succeeded or failed.
-    /// </summary>
-    bool IsSuccess { get; }
+    /// <typeparam name="TOutput">The type of data.</typeparam>
+    public interface IResult<out TOutput> : IResult
+    {
+        /// <summary>
+        /// Gets the data result of a operation.
+        /// </summary>
+        TOutput Output { get; }
+    }
 
     /// <summary>
-    /// Gets a collection of errors; this collection should only be populated if the result represents a failure.
+    /// Indicates the success or failure of a an operation with a collection for errors (if applicable).
     /// </summary>
-    IEnumerable<string> Errors { get; }
+    public interface IResult
+    {
+        /// <summary>
+        /// Gets a value indicating whether gets a flag indicating whether the operation succeeded or failed.
+        /// </summary>
+        bool IsSuccess { get; }
+
+        /// <summary>
+        /// Gets a collection of errors; this collection should only be populated if the result represents a failure.
+        /// </summary>
+        IEnumerable<string> Errors { get; }
+    }
 }

--- a/src/Audacia.Core/Paging/IPage.cs
+++ b/src/Audacia.Core/Paging/IPage.cs
@@ -1,25 +1,26 @@
 ﻿using System.Collections.Generic;
 
-namespace Audacia.Core;
-
-/// <summary>
-/// Interface for handling the result of paging. (See <see cref="PagingRequest"/>).
-/// </summary>
-/// <typeparam name="T">The type of the paged data that is returned.</typeparam>
-public interface IPage<out T>
+namespace Audacia.Core
 {
     /// <summary>
-    /// Gets a paged set of data for one page. (See <see cref="PagingRequest.PageSize"/>).
+    /// Interface for handling the result of paging. (See <see cref="PagingRequest"/>).
     /// </summary>
-    IEnumerable<T> Data { get; }
+    /// <typeparam name="T">The type of the paged data that is returned.</typeparam>
+    public interface IPage<out T>
+    {
+        /// <summary>
+        /// Gets a paged set of data for one page. (See <see cref="PagingRequest.PageSize"/>).
+        /// </summary>
+        IEnumerable<T> Data { get; }
 
-    /// <summary>
-    /// Gets the number of pages <see cref="Data"/> will span over. (See <see cref="PagingRequest.PageSize"/>).
-    /// </summary>
-    int TotalPages { get; }
+        /// <summary>
+        /// Gets the number of pages <see cref="Data"/> will span over. (See <see cref="PagingRequest.PageSize"/>).
+        /// </summary>
+        int TotalPages { get; }
 
-    /// <summary>
-    /// Gets the total number of records, including <see cref="Data"/>. (See <see cref="PagingRequest"/>).
-    /// </summary>
-    int TotalRecords { get; }
+        /// <summary>
+        /// Gets the total number of records, including <see cref="Data"/>. (See <see cref="PagingRequest"/>).
+        /// </summary>
+        int TotalRecords { get; }
+    }
 }

--- a/src/Audacia.Core/Paging/Page.cs
+++ b/src/Audacia.Core/Paging/Page.cs
@@ -1,99 +1,100 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 
-namespace Audacia.Core;
-
-/// <summary>
-/// A results page of type <typeparamref name="T"/>.
-/// </summary>
-/// <typeparam name="T">The type of the collection.</typeparam>
-public class Page<T> : IPage<T>
+namespace Audacia.Core
 {
     /// <summary>
-    /// Gets the number of pages in the data before being filtered.
-    /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "AV1710:Member name includes the name of its containing type", 
-        Justification = "The 'TotalPages' property in the 'Page' class does not merely repeat the type name, but instead represents a different concept: the total number of 'Page' instances in a higher-level object. The name is chosen to clearly express this concept and make the code more understandable.")]
-    public int TotalPages { get; }
-
-    /// <summary>
-    /// Gets the number of records in the data before being filtered.
-    /// </summary>
-    public int TotalRecords { get; }
-
-    /// <summary>
-    /// Gets a collection of records after sorting and paging has been applied.
-    /// </summary>
-    public IEnumerable<T> Data { get; }
-
-    /// <summary>
     /// A results page of type <typeparamref name="T"/>.
     /// </summary>
-    /// <param name="query">A LINQ query.</param>
-    /// <param name="sortablePagingRequest">Request to sort and apply paging to a query.</param>
-    public Page(IQueryable<T> query, SortablePagingRequest sortablePagingRequest)
+    /// <typeparam name="T">The type of the collection.</typeparam>
+    public class Page<T> : IPage<T>
     {
-        // Get total count before paging is applied
-        TotalRecords = query.Count();
+        /// <summary>
+        /// Gets the number of pages in the data before being filtered.
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "AV1710:Member name includes the name of its containing type",
+            Justification = "The 'TotalPages' property in the 'Page' class does not merely repeat the type name, but instead represents a different concept: the total number of 'Page' instances in a higher-level object. The name is chosen to clearly express this concept and make the code more understandable.")]
+        public int TotalPages { get; }
 
-        var specification = new PagingSpecification<T>(query)
-            .ConfigurePaging(sortablePagingRequest)
-            .ConfigureSorting(sortablePagingRequest)
-            .UseSorting()
-            .UsePaging();
+        /// <summary>
+        /// Gets the number of records in the data before being filtered.
+        /// </summary>
+        public int TotalRecords { get; }
 
-        TotalPages = specification.GetTotalPages(TotalRecords);
-        Data = specification.Query.ToList();
-    }
+        /// <summary>
+        /// Gets a collection of records after sorting and paging has been applied.
+        /// </summary>
+        public IEnumerable<T> Data { get; }
 
-    /// <summary>
-    /// A results page of type <typeparamref name="T"/>.
-    /// </summary>
-    /// <param name="query">A LINQ query.</param>
-    /// <param name="pagingRequest">Request apply paging to a query.</param>
-    public Page(IQueryable<T> query, PagingRequest pagingRequest)
-    {
-        // Get total count before paging is applied
-        TotalRecords = query.Count();
+        /// <summary>
+        /// A results page of type <typeparamref name="T"/>.
+        /// </summary>
+        /// <param name="query">A LINQ query.</param>
+        /// <param name="sortablePagingRequest">Request to sort and apply paging to a query.</param>
+        public Page(IQueryable<T> query, SortablePagingRequest sortablePagingRequest)
+        {
+            // Get total count before paging is applied
+            TotalRecords = query.Count();
 
-        var specification = new PagingSpecification<T>(query)
-            .ConfigurePaging(pagingRequest)
-            .UsePaging();
+            var specification = new PagingSpecification<T>(query)
+                .ConfigurePaging(sortablePagingRequest)
+                .ConfigureSorting(sortablePagingRequest)
+                .UseSorting()
+                .UsePaging();
 
-        TotalPages = specification.GetTotalPages(TotalRecords);
-        Data = specification.Query.ToList();
-    }
+            TotalPages = specification.GetTotalPages(TotalRecords);
+            Data = specification.Query.ToList();
+        }
 
-    /// <summary>
-    /// A results page of type <typeparamref name="T"/>.
-    /// </summary>
-    /// <param name="enumerable">A collection of data.</param>
-    /// <param name="totalPages">The number of pages in the data before being filtered.</param>
-    /// <param name="totalRecords">The number of records in the data before being filtered.</param>
-    public Page(IEnumerable<T> enumerable, int totalPages, int totalRecords)
-    {
-        Data = enumerable;
-        TotalPages = totalPages;
-        TotalRecords = totalRecords;
-    }
+        /// <summary>
+        /// A results page of type <typeparamref name="T"/>.
+        /// </summary>
+        /// <param name="query">A LINQ query.</param>
+        /// <param name="pagingRequest">Request apply paging to a query.</param>
+        public Page(IQueryable<T> query, PagingRequest pagingRequest)
+        {
+            // Get total count before paging is applied
+            TotalRecords = query.Count();
 
-    /// <summary>
-    /// A results page of type <typeparamref name="T"/>.
-    /// </summary>
-    /// <param name="enumerable">A collection of data.</param>
-    /// <param name="sortablePagingRequest">Request to sort and apply paging to a query.</param>
-    public Page(IEnumerable<T> enumerable, SortablePagingRequest sortablePagingRequest)
-        : this(enumerable.AsQueryable(), sortablePagingRequest)
-    {
-    }
+            var specification = new PagingSpecification<T>(query)
+                .ConfigurePaging(pagingRequest)
+                .UsePaging();
 
-    /// <summary>
-    /// A results page of type <typeparamref name="T"/>.
-    /// </summary>
-    /// <param name="enumerable">A collection of data.</param>
-    /// <param name="pagingRequest">Request apply paging to a query.</param>
-    public Page(IEnumerable<T> enumerable, PagingRequest pagingRequest)
-        : this(enumerable.AsQueryable(), pagingRequest)
-    {
+            TotalPages = specification.GetTotalPages(TotalRecords);
+            Data = specification.Query.ToList();
+        }
+
+        /// <summary>
+        /// A results page of type <typeparamref name="T"/>.
+        /// </summary>
+        /// <param name="enumerable">A collection of data.</param>
+        /// <param name="totalPages">The number of pages in the data before being filtered.</param>
+        /// <param name="totalRecords">The number of records in the data before being filtered.</param>
+        public Page(IEnumerable<T> enumerable, int totalPages, int totalRecords)
+        {
+            Data = enumerable;
+            TotalPages = totalPages;
+            TotalRecords = totalRecords;
+        }
+
+        /// <summary>
+        /// A results page of type <typeparamref name="T"/>.
+        /// </summary>
+        /// <param name="enumerable">A collection of data.</param>
+        /// <param name="sortablePagingRequest">Request to sort and apply paging to a query.</param>
+        public Page(IEnumerable<T> enumerable, SortablePagingRequest sortablePagingRequest)
+            : this(enumerable.AsQueryable(), sortablePagingRequest)
+        {
+        }
+
+        /// <summary>
+        /// A results page of type <typeparamref name="T"/>.
+        /// </summary>
+        /// <param name="enumerable">A collection of data.</param>
+        /// <param name="pagingRequest">Request apply paging to a query.</param>
+        public Page(IEnumerable<T> enumerable, PagingRequest pagingRequest)
+            : this(enumerable.AsQueryable(), pagingRequest)
+        {
+        }
     }
 }

--- a/src/Audacia.Core/Paging/PagingEnumerableExtensions.cs
+++ b/src/Audacia.Core/Paging/PagingEnumerableExtensions.cs
@@ -1,21 +1,22 @@
 ﻿using System.Collections.Generic;
 
-namespace Audacia.Core.Paging;
-
-/// <summary>
-/// Extensions to <see cref="IEnumerable{T}"/> pertaining to paging queries.
-/// </summary>
-public static class PagingEnumerableExtensions
+namespace Audacia.Core.Paging
 {
     /// <summary>
-    /// Gets a page of data from the given <paramref name="query"/>, where the <paramref name="pagingRequest"/> contains the page size, etc.
+    /// Extensions to <see cref="IEnumerable{T}"/> pertaining to paging queries.
     /// </summary>
-    /// <typeparam name="T">The type of data contained in the given <paramref name="query"/>.</typeparam>
-    /// <param name="query">The query to page.</param>
-    /// <param name="pagingRequest">The object containing paging-related parameters.</param>
-    /// <returns>A page of data containing items of type <typeparamref name="T"/>.</returns>
-    public static IPage<T> ToPage<T>(this IEnumerable<T> query, SortablePagingRequest pagingRequest)
+    public static class PagingEnumerableExtensions
     {
-        return new Page<T>(query, pagingRequest);
+        /// <summary>
+        /// Gets a page of data from the given <paramref name="query"/>, where the <paramref name="pagingRequest"/> contains the page size, etc.
+        /// </summary>
+        /// <typeparam name="T">The type of data contained in the given <paramref name="query"/>.</typeparam>
+        /// <param name="query">The query to page.</param>
+        /// <param name="pagingRequest">The object containing paging-related parameters.</param>
+        /// <returns>A page of data containing items of type <typeparamref name="T"/>.</returns>
+        public static IPage<T> ToPage<T>(this IEnumerable<T> query, SortablePagingRequest pagingRequest)
+        {
+            return new Page<T>(query, pagingRequest);
+        }
     }
 }

--- a/src/Audacia.Core/Paging/PagingRequest.cs
+++ b/src/Audacia.Core/Paging/PagingRequest.cs
@@ -1,37 +1,38 @@
-﻿namespace Audacia.Core;
-
-/// <summary>
-/// Request to apply paging to a list of results.
-/// </summary>
-public class PagingRequest
+﻿namespace Audacia.Core
 {
-    /// <summary>
-    /// Request to apply paging to a list of results with default values.
-    /// </summary>
-    public PagingRequest()
-        : this(int.MaxValue, 0)
-    {
-        /* Required for injection */
-    }
-
     /// <summary>
     /// Request to apply paging to a list of results.
     /// </summary>
-    /// <param name="pageSize">The number of results to show per page.</param>
-    /// <param name="pageNumber">Which page of results to return.</param>
-    public PagingRequest(int pageSize = int.MaxValue, int pageNumber = 0)
+    public class PagingRequest
     {
-        PageSize = pageSize;
-        PageNumber = pageNumber;
+        /// <summary>
+        /// Request to apply paging to a list of results with default values.
+        /// </summary>
+        public PagingRequest()
+            : this(int.MaxValue, 0)
+        {
+            /* Required for injection */
+        }
+
+        /// <summary>
+        /// Request to apply paging to a list of results.
+        /// </summary>
+        /// <param name="pageSize">The number of results to show per page.</param>
+        /// <param name="pageNumber">Which page of results to return.</param>
+        public PagingRequest(int pageSize = int.MaxValue, int pageNumber = 0)
+        {
+            PageSize = pageSize;
+            PageNumber = pageNumber;
+        }
+
+        /// <summary>
+        /// Gets or sets the number of results we'll show per page.
+        /// </summary>
+        public int? PageSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets which page of results to return. Pages start at 1.
+        /// </summary>
+        public int PageNumber { get; set; }
     }
-
-    /// <summary>
-    /// Gets or sets the number of results we'll show per page.
-    /// </summary>
-    public int? PageSize { get; set; }
-
-    /// <summary>
-    /// Gets or sets which page of results to return. Pages start at 1.
-    /// </summary>
-    public int PageNumber { get; set; }
 }

--- a/src/Audacia.Core/Paging/PagingSpecification.cs
+++ b/src/Audacia.Core/Paging/PagingSpecification.cs
@@ -4,154 +4,161 @@ using System.Linq.Expressions;
 using System.Reflection;
 using Audacia.Core.Extensions;
 
-namespace Audacia.Core;
-
-/// <summary>
-/// Specification for how we'll page a queryable of <typeparamref name="T"/>.
-/// </summary>
-/// <typeparam name="T">The return type of the query.</typeparam>
-public class PagingSpecification<T> 
+namespace Audacia.Core
 {
     /// <summary>
-    /// Gets the underlying query for the data to be paged.
+    /// Specification for how we'll page a queryable of <typeparamref name="T"/>.
     /// </summary>
-    public IQueryable<T> Query { get; private set; }
-
-    private int _pageNumber;
-    private int _pageSize = int.MaxValue;
-    private static readonly Type Type = typeof(T);
-    private string _sortProperty = string.Empty;
-    private bool _descending = false;
-
-    /// <summary>
-    /// Construct a specification for how we'll page a queryable of <typeparamref name="T"/>.
-    /// </summary>
-    /// <param name="query">The query to implement a specification.</param>
-    public PagingSpecification(IQueryable<T> query)
+    /// <typeparam name="T">The return type of the query.</typeparam>
+    public class PagingSpecification<T>
     {
-        Query = query;
-    }
+        /// <summary>
+        /// Gets the underlying query for the data to be paged.
+        /// </summary>
+        public IQueryable<T> Query { get; private set; }
 
-    /// <summary>
-    /// Record paging information for use when getting the page of results.
-    /// </summary>
-    /// <param name="pagingRequest">Contains the information required for paging.</param>
-    /// <returns>A paging specifications with the paging provided from <paramref name="pagingRequest"/>.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="pagingRequest"/> is null.</exception>
-    public PagingSpecification<T> ConfigurePaging(PagingRequest pagingRequest)
-    {
-        ArgumentNullException.ThrowIfNull(pagingRequest);
+        private int _pageNumber;
+        private int _pageSize = int.MaxValue;
+        private static readonly Type Type = typeof(T);
+        private string _sortProperty = string.Empty;
+        private bool _descending = false;
 
-        return ConfigurePaging(pagingRequest.PageSize, pagingRequest.PageNumber);
-    }
-
-    /// <summary>
-    /// Record paging information for use when getting the page of results.
-    /// </summary>
-    /// <param name="pageSize">The number of results to show per page.</param>
-    /// <param name="pageNumber">Which page of results we want to show. The first page is 1.</param>
-    /// <returns>A paging specifications with the <paramref name="pageSize"/> and <paramref name="pageNumber"/>.</returns>
-    public virtual PagingSpecification<T> ConfigurePaging(int? pageSize, int pageNumber)
-    {
-        _pageSize = pageSize ?? int.MaxValue;
-        _pageNumber = pageNumber;
-        return this;
-    }
-
-    /// <summary>
-    /// Record sorting information for use when sorting the results.
-    /// </summary>
-    /// <param name="pagingRequest">Contains the information required for sorting.</param>
-    /// <returns>A paging specifications with the sorting provided from <paramref name="pagingRequest"/>.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="pagingRequest"/> is null.</exception>
-    public PagingSpecification<T> ConfigureSorting(SortablePagingRequest pagingRequest)
-    {
-        ArgumentNullException.ThrowIfNull(pagingRequest);
-
-        return ConfigureSorting(pagingRequest.SortProperty, pagingRequest.Descending);
-    }
-
-    /// <summary>
-    /// Record sorting information for use when sorting the results.
-    /// </summary>
-    /// <param name="sortProperty">The property of <typeparamref name="T"/> we want to sort.</param>
-    /// <param name="descending">The sort direction.</param>
-    /// <returns>A paging specifications with the <paramref name="sortProperty"/> and <paramref name="descending"/>.</returns>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1564:Parameter in public or internal member is of type bool or bool?", Justification = "Makes sense when passed from UI.")]
-    public virtual PagingSpecification<T> ConfigureSorting(string sortProperty, bool descending)
-    {
-        _sortProperty = sortProperty;
-        _descending = descending;
-        return this;
-    }
-
-    /// <summary>
-    /// Sort the query based on the configured sorting information.
-    /// </summary>
-    /// <exception cref="ArgumentException">If our configured sortProperty is invalid.</exception>
-    /// <returns>Paging specification with sorting enabled.</returns>
-    public PagingSpecification<T> UseSorting()
-    {
-        SortQuery();
-        return this;
-    }
-
-    /// <summary>
-    /// Update the Query to return a page of results.
-    /// </summary>
-    /// <returns>Paging specification with paging enabled.</returns>
-    public PagingSpecification<T> UsePaging()
-    {
-        Query = Query.Skip(_pageNumber * _pageSize).Take(_pageSize);
-        return this;
-    }
-
-    /// <summary>
-    /// Get the number of pages the results take up, based on the provided <paramref name="totalRecords"/>.
-    /// </summary>
-    /// <param name="totalRecords">The total number of records.</param>
-    /// <returns>The total number of pages possible with the provided <paramref name="totalRecords"/> count.</returns>
-    public int GetTotalPages(int totalRecords)
-    {
-        var totalPages = Math.Max((int)Math.Ceiling(totalRecords / (double)_pageSize), 1);
-        // Set the page number to 1 if we've asked for a larger page than we have. 
-        _pageNumber = _pageNumber > totalPages ? 1 : _pageNumber;
-        return totalPages;
-    }
-
-    private void SortQuery()
-    {
-        if (string.IsNullOrWhiteSpace(_sortProperty))
+        /// <summary>
+        /// Construct a specification for how we'll page a queryable of <typeparamref name="T"/>.
+        /// </summary>
+        /// <param name="query">The query to implement a specification.</param>
+        public PagingSpecification(IQueryable<T> query)
         {
-            return;
+            Query = query;
         }
 
-        //Upper case first to account for lower case JSON
-        var propertyInfo = Type.GetProperty(_sortProperty.UpperCaseFirst());
-
-        if (propertyInfo == null)
+        /// <summary>
+        /// Record paging information for use when getting the page of results.
+        /// </summary>
+        /// <param name="pagingRequest">Contains the information required for paging.</param>
+        /// <returns>A paging specifications with the paging provided from <paramref name="pagingRequest"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="pagingRequest"/> is null.</exception>
+        public PagingSpecification<T> ConfigurePaging(PagingRequest pagingRequest)
         {
-            // Someone has provided a sort property that doesn't exist on the result
-            throw new ArgumentException($"Invalid Sort Property: {_sortProperty}");
+            if (pagingRequest == null)
+            {
+                throw new ArgumentNullException(nameof(pagingRequest));
+            }
+
+            return ConfigurePaging(pagingRequest.PageSize, pagingRequest.PageNumber);
         }
 
-        var orderByExpression = GetOrderByExpression(propertyInfo);
+        /// <summary>
+        /// Record paging information for use when getting the page of results.
+        /// </summary>
+        /// <param name="pageSize">The number of results to show per page.</param>
+        /// <param name="pageNumber">Which page of results we want to show. The first page is 1.</param>
+        /// <returns>A paging specifications with the <paramref name="pageSize"/> and <paramref name="pageNumber"/>.</returns>
+        public virtual PagingSpecification<T> ConfigurePaging(int? pageSize, int pageNumber)
+        {
+            _pageSize = pageSize ?? int.MaxValue;
+            _pageNumber = pageNumber;
+            return this;
+        }
 
-        var orderMethod = _descending ? nameof(Queryable.OrderByDescending) : nameof(Queryable.OrderBy);
+        /// <summary>
+        /// Record sorting information for use when sorting the results.
+        /// </summary>
+        /// <param name="pagingRequest">Contains the information required for sorting.</param>
+        /// <returns>A paging specifications with the sorting provided from <paramref name="pagingRequest"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="pagingRequest"/> is null.</exception>
+        public PagingSpecification<T> ConfigureSorting(SortablePagingRequest pagingRequest)
+        {
+            if (pagingRequest == null)
+            {
+                throw new ArgumentNullException(nameof(pagingRequest));
+            }
 
-        var method =
-            typeof(Queryable).GetMethods().First(m => m.Name == orderMethod && m.GetParameters().Length == 2);
+            return ConfigureSorting(pagingRequest.SortProperty, pagingRequest.Descending);
+        }
 
-        var genericMethod = method.MakeGenericMethod(Type, propertyInfo.PropertyType);
+        /// <summary>
+        /// Record sorting information for use when sorting the results.
+        /// </summary>
+        /// <param name="sortProperty">The property of <typeparamref name="T"/> we want to sort.</param>
+        /// <param name="descending">The sort direction.</param>
+        /// <returns>A paging specifications with the <paramref name="sortProperty"/> and <paramref name="descending"/>.</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1564:Parameter in public or internal member is of type bool or bool?", Justification = "Makes sense when passed from UI.")]
+        public virtual PagingSpecification<T> ConfigureSorting(string sortProperty, bool descending)
+        {
+            _sortProperty = sortProperty;
+            _descending = descending;
+            return this;
+        }
 
-        Query = (genericMethod.Invoke(null, new object[] { Query, orderByExpression }) as IQueryable<T>) ?? default!;
-    }
+        /// <summary>
+        /// Sort the query based on the configured sorting information.
+        /// </summary>
+        /// <exception cref="ArgumentException">If our configured sortProperty is invalid.</exception>
+        /// <returns>Paging specification with sorting enabled.</returns>
+        public PagingSpecification<T> UseSorting()
+        {
+            SortQuery();
+            return this;
+        }
 
-    private static LambdaExpression GetOrderByExpression(MemberInfo propertyInfo)
-    {
-        var parameterExpression = Expression.Parameter(Type);
-        var propertyExpression = Expression.PropertyOrField(parameterExpression, propertyInfo.Name);
+        /// <summary>
+        /// Update the Query to return a page of results.
+        /// </summary>
+        /// <returns>Paging specification with paging enabled.</returns>
+        public PagingSpecification<T> UsePaging()
+        {
+            Query = Query.Skip(_pageNumber * _pageSize).Take(_pageSize);
+            return this;
+        }
 
-        return Expression.Lambda(propertyExpression, parameterExpression);
+        /// <summary>
+        /// Get the number of pages the results take up, based on the provided <paramref name="totalRecords"/>.
+        /// </summary>
+        /// <param name="totalRecords">The total number of records.</param>
+        /// <returns>The total number of pages possible with the provided <paramref name="totalRecords"/> count.</returns>
+        public int GetTotalPages(int totalRecords)
+        {
+            var totalPages = Math.Max((int)Math.Ceiling(totalRecords / (double)_pageSize), 1);
+            // Set the page number to 1 if we've asked for a larger page than we have. 
+            _pageNumber = _pageNumber > totalPages ? 1 : _pageNumber;
+            return totalPages;
+        }
+
+        private void SortQuery()
+        {
+            if (string.IsNullOrWhiteSpace(_sortProperty))
+            {
+                return;
+            }
+
+            //Upper case first to account for lower case JSON
+            var propertyInfo = Type.GetProperty(_sortProperty.UpperCaseFirst());
+
+            if (propertyInfo == null)
+            {
+                // Someone has provided a sort property that doesn't exist on the result
+                throw new ArgumentException($"Invalid Sort Property: {_sortProperty}");
+            }
+
+            var orderByExpression = GetOrderByExpression(propertyInfo);
+
+            var orderMethod = _descending ? nameof(Queryable.OrderByDescending) : nameof(Queryable.OrderBy);
+
+            var method =
+                typeof(Queryable).GetMethods().First(m => m.Name == orderMethod && m.GetParameters().Length == 2);
+
+            var genericMethod = method.MakeGenericMethod(Type, propertyInfo.PropertyType);
+
+            Query = (genericMethod.Invoke(null, new object[] { Query, orderByExpression }) as IQueryable<T>) ?? default!;
+        }
+
+        private static LambdaExpression GetOrderByExpression(MemberInfo propertyInfo)
+        {
+            var parameterExpression = Expression.Parameter(Type);
+            var propertyExpression = Expression.PropertyOrField(parameterExpression, propertyInfo.Name);
+
+            return Expression.Lambda(propertyExpression, parameterExpression);
+        }
     }
 }

--- a/src/Audacia.Core/Paging/SortablePagingRequest.cs
+++ b/src/Audacia.Core/Paging/SortablePagingRequest.cs
@@ -1,37 +1,38 @@
-﻿namespace Audacia.Core;
-
-/// <summary>
-/// Request to sort, and apply paging to a list of results.
-/// </summary>
-public class SortablePagingRequest : PagingRequest
+﻿namespace Audacia.Core
 {
     /// <summary>
-    /// Initializes a new instance of <see cref="SortablePagingRequest"/>.
+    /// Request to sort, and apply paging to a list of results.
     /// </summary>
-    public SortablePagingRequest()
-        : this(int.MaxValue, 0)
+    public class SortablePagingRequest : PagingRequest
     {
-        /* Required for injection */
+        /// <summary>
+        /// Initializes a new instance of <see cref="SortablePagingRequest"/>.
+        /// </summary>
+        public SortablePagingRequest()
+            : this(int.MaxValue, 0)
+        {
+            /* Required for injection */
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="SortablePagingRequest"/>.
+        /// </summary>
+        /// <param name="pageSize">The size of the page.</param>
+        /// <param name="pageNumber">The page number.</param>
+        public SortablePagingRequest(int pageSize = int.MaxValue, int pageNumber = 0)
+            : base(pageSize, pageNumber)
+        {
+            SortProperty = string.Empty;
+        }
+
+        /// <summary>
+        /// Gets or sets the property of the destination type we'll sort by.
+        /// </summary>
+        public string SortProperty { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether gets or sets a value indicating the sort direction.
+        /// </summary>
+        public bool Descending { get; set; }
     }
-
-    /// <summary>
-    /// Initializes a new instance of <see cref="SortablePagingRequest"/>.
-    /// </summary>
-    /// <param name="pageSize">The size of the page.</param>
-    /// <param name="pageNumber">The page number.</param>
-    public SortablePagingRequest(int pageSize = int.MaxValue, int pageNumber = 0)
-        : base(pageSize, pageNumber)
-    {
-        SortProperty = string.Empty;
-    }
-
-    /// <summary>
-    /// Gets or sets the property of the destination type we'll sort by.
-    /// </summary>
-    public string SortProperty { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether gets or sets a value indicating the sort direction.
-    /// </summary>
-    public bool Descending { get; set; }
 }


### PR DESCRIPTION
Updated `<targetframework>` to `netstandard2.1`.
- Namespaces changed to block scoped
- Updated `ArgumentNullException` statements as this was a `NET6.0` format


| Action | Done? |
| --- | --- |
| Code compiles and unit tests all pass locally | ✔ |
| Debug/console log code removed | ✔ |
| Commented out code removed | ✔ |
| Unit tests added/updated | ✔ |
| README updated | ✔ |
| Considered: <br /> - Performance <br /> - Security <br /> - Logging | ✔ |
| Licenses of any new/upgraded dependencies checked, with no copyleft dependencies introduced | ✔ |