### PR TITLE
bug: 174780- Add unit test to check parsing of enum number members as…

### DIFF
--- a/src/Audacia.Core/EnumMember.cs
+++ b/src/Audacia.Core/EnumMember.cs
@@ -296,7 +296,7 @@ namespace Audacia.Core
         /// <param name="enumValue">Return value of the enum if parsed.</param>
         /// <returns>The parsed enum.</returns>
         /// <exception cref="OverflowException"> Throws when the enum member is out of range.</exception>
-        public static bool TryParseEnumAsString(Type type, string value, out object? enumValue)
+        private static bool TryParseEnumAsString(Type type, string value, out object? enumValue)
         {
             bool enumDefined;
 
@@ -312,6 +312,10 @@ namespace Audacia.Core
                 enumValue = null;
                 enumDefined = false;
             }
+            
+            /*When an enum isnt defined, but still has a value, this is an error state and due to backwards
+            //compatability reasons (see unit test Check_that_overflow_exception_is_correctly_called()) an exception is
+            thrown*/
             
             if (!enumDefined && enumValue != null)
             {

--- a/src/Audacia.Core/EnumMember.cs
+++ b/src/Audacia.Core/EnumMember.cs
@@ -264,8 +264,11 @@ namespace Audacia.Core
 
             value = SanitizeDisplayNameString(value) ?? string.Empty;
             ValidateValueString(value);
-
-            object? enumValue = GetEnumValue(enumType, value);
+            
+            if (TryParseEnumAsString(enumType, value, out var enumValue))
+            {
+                return enumValue;
+            }
 
             // Get an enumerable of enum options
             var fields = enumType.GetFields().Where(f => f.IsStatic);
@@ -283,6 +286,39 @@ namespace Audacia.Core
             }
 
             throw new ArgumentException($"Requested value '{value}' was not found.");
+        }
+
+        /// <summary>
+        /// Attempts to parse the enum as a string and return the relevant member.
+        /// </summary>
+        /// <param name="type">Type of Enum.</param>
+        /// <param name="value">Value to convert.</param>
+        /// <param name="enumValue">Return value of the enum if parsed.</param>
+        /// <returns>The parsed enum.</returns>
+        /// <exception cref="OverflowException"> Throws when the enum member is out of range.</exception>
+        public static bool TryParseEnumAsString(Type type, string value, out object? enumValue)
+        {
+            bool enumDefined;
+
+            try
+            {
+                // Match by number value or field name
+                enumValue = Enum.Parse(type, value, ignoreCase: true);
+                enumDefined = Enum.IsDefined(type, enumValue);
+            }
+            catch (ArgumentException)
+            {
+                // Ignore enum value not found error
+                enumValue = null;
+                enumDefined = false;
+            }
+            
+            if (!enumDefined && enumValue != null)
+            {
+                throw new OverflowException($"Value '{value}' is outside the range of '{(type == null ? "the provided enum type" : type.Name)}'.");
+            }
+
+            return enumDefined;
         }
 
         /// <summary>
@@ -437,33 +473,6 @@ namespace Audacia.Core
             {
                 throw new ArgumentException("Value cannot be empty or whitespace.", nameof(value));
             }
-        }
-
-        private static object? GetEnumValue(Type enumType, string? value)
-        {
-            bool enumDefined;
-            object? enumValue;
-
-            try
-            {
-                // Match by number value or field name
-                enumValue = Enum.Parse(enumType, value ?? string.Empty, ignoreCase: true);
-                enumDefined = Enum.IsDefined(enumType, enumValue);
-            }
-            catch (ArgumentException)
-            {
-                // Ignore enum value not found error
-                enumValue = null;
-                enumDefined = false;
-            }
-
-            if (!enumDefined && enumValue != null)
-            {
-                throw new OverflowException($"Value '{value}' is outside the range of '{enumType.Name}'.");
-            }
-
-            // Enum was parsed successfully, and is in defined on the enum type
-            return enumValue;
         }
     }
 }

--- a/tests/Audacia.Core.Tests/EnumMember/EnumMemberTests.cs
+++ b/tests/Audacia.Core.Tests/EnumMember/EnumMemberTests.cs
@@ -92,7 +92,7 @@ namespace Audacia.Core.Tests.EnumMember
         }
 
         [Fact]
-        public static void Check_that_overflow_exception_is_correcrtly_called()
+        public static void Check_that_overflow_exception_is_correctly_called()
         {
             //Arrange 
             var value = "100";

--- a/tests/Audacia.Core.Tests/EnumMember/EnumMemberTests.cs
+++ b/tests/Audacia.Core.Tests/EnumMember/EnumMemberTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
 using System.Runtime.Serialization;
 using Audacia.Core;
 using FluentAssertions;
@@ -114,6 +115,43 @@ namespace Audacia.Core.Tests.EnumMember
 
             //Assert
             Assert.Equal("Requested value 'March' was not found.", exception.Message);
+        }
+        
+        [Fact]
+        public static void Check_that_string_enum_value_gives_correct_member()
+        {
+            //Arrange 
+            var expected = new Day[]
+            {
+                Day.Wednesday,
+                Day.Tuesday,
+                Day.Thursday
+            };
+            
+            var stringMembers = new string[]
+            {
+                "3",
+                "2",
+                "4"
+            };
+
+            var actual = new List<Day>();
+            var dayType = typeof(Day);
+            //Act
+            foreach (var day in stringMembers)
+            {
+                Day result = default(Day);
+                if (Core.EnumMember.TryParse(dayType, day, out var enumValue))
+                {
+                    result = (Day)enumValue;
+                    Debug.Assert(enumValue != null, nameof(enumValue) + " != null");
+                } 
+                
+                actual.Add(result);
+            }
+            
+            //Assert
+            Assert.Equal(expected, actual.ToArray());
         }
     }
 }


### PR DESCRIPTION
… strings and fix existing code for this

| Action | Done? |
| --- | --- |
| Code compiles and unit tests all pass locally | ✔ |
| Debug/console log code removed | ✔ |
| Commented out code removed | ✔|
| Unit tests added/updated | ✔ |
| README updated | ❌ |
| Considered: <br /> - Performance <br /> - Security <br /> - Logging | ✔ |
| Licenses of any new/upgraded dependencies checked, with no copyleft dependencies introduced | ✔ |