### PR TITLE
fix: ensure created lambda uses it's own parameters when replacing

### DIFF
--- a/src/Audacia.Core/Extensions/Helpers/ParameterReplacer.cs
+++ b/src/Audacia.Core/Extensions/Helpers/ParameterReplacer.cs
@@ -36,7 +36,8 @@ namespace Audacia.Core.Extensions.Helpers
         protected override Expression VisitLambda<T>(Expression<T> node)
         {
             _parameters = VisitAndConvert(node.Parameters, nameof(VisitLambda));
-            return Expression.Lambda(Visit(node.Body), _parameters);
+            var nodeParameters = _parameters;
+            return Expression.Lambda(Visit(node.Body), nodeParameters);
         }
 
         /// <inheritdoc />
@@ -53,7 +54,7 @@ namespace Audacia.Core.Extensions.Helpers
 
                 if (expression != null)
                 {
-                    Expression.Property(expression, node!.Member.Name);
+                    return Expression.Property(expression, node!.Member.Name);
                 }
             }
 

--- a/tests/Audacia.Core.Tests/Extensions/ExpressionExtensionsTests.cs
+++ b/tests/Audacia.Core.Tests/Extensions/ExpressionExtensionsTests.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Audacia.Core.Extensions;
+using FluentAssertions;
+using Xunit;
+
+namespace Audacia.Core.Tests.Extensions
+{
+    public class ExpressionExtensionsTests
+    {
+        [Fact]
+        public void Generic_expression_is_converted()
+        {
+            Expression<Func<IHavePet<IPet>, bool>> hasPet =
+                r => r.Pets.Any();
+            var dogOwner = new DogOwner()
+            {
+                Pets = new List<Dog>
+                {
+                    new() { Name = "Toby" }
+                }
+            };
+
+            var convertedExpression = hasPet
+                .ConvertGenericTypeArgument<IHavePet<IPet>, DogOwner, bool>()!;
+
+            var result = convertedExpression.Compile().Invoke(dogOwner);
+
+            result.Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData("Toby", true)]
+        [InlineData("Deedee", false)]
+        public void Generic_expression_with_generic_lambda_is_converted(string dogName, bool expectedValue)
+        {
+            Expression<Func<IHavePet<IPet>, bool>> hasPetCalledToby =
+                r => r.Pets.Any(p => p.Name == "Toby");
+            var dogOwner = new DogOwner()
+            {
+                Pets = new List<Dog>
+                {
+                    new() { Name = dogName }
+                }
+            };
+
+            var convertedExpression = hasPetCalledToby
+                .ConvertGenericTypeArgument<IHavePet<IPet>, DogOwner, bool>()!;
+
+            var result = convertedExpression.Compile().Invoke(dogOwner);
+
+            result.Should().Be(expectedValue);
+        }
+
+        private interface IHavePet<TPet> where TPet : IPet
+        {
+            ICollection<TPet> Pets { get; set; }
+        }
+
+        private interface IPet
+        {
+            public string Name { get; set; }
+        }
+
+        private class Dog : IPet
+        {
+            public string Name { get; set; }
+        }
+
+        private class DogOwner : IHavePet<Dog>
+        {
+            public ICollection<Dog> Pets { get; set; } = new List<Dog>();
+        }
+    }
+}


### PR DESCRIPTION
After visiting the root node, the expression visitor would visit child nodes and on visiting a child lambda would then replace the `_parameter` class-level field, so after returning to the root node `_parameter` would contain parameters for the wrong node and use the wrong parameters when creating the lambda. This fix stores the parameters in a local variable to use them after visiting the body of the node. Also have restored a missing `return` from the `VisitMember` method and added some basic tests to check that expressions are correctly created when they have lambdas within them.

### Version changed and CHANGELOG updated
- ❎ No version change required - version will be updated as part of other work in #184907

### Code ready for review
- ✔ Code compiles, all tests pass, no debug/console statements or commented out code left in

### Unit tests added/updated
- ✔ Tests added/updated for all new and modified code

### README or other documentation updated
- ❎ Changes do not require documentation

### Dependency licenses
- ❎ No new/upgraded dependencies